### PR TITLE
Multi-output y / batched equation search

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,5 +2,5 @@
 SymbolicRegression = "8254be44-1295-4e6a-a16d-46603ac705cb"
 
 [compat]
-SymbolicRegression = "0.5.16"
+SymbolicRegression = "0.6.0"
 julia = "1.5"

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -278,12 +278,13 @@ def pysr(X=None, y=None, weights=None,
     if X is None:
         X, y = _using_test_input(X, test, y)
 
-    if len(y.shape) == 2:
-        multioutput = True
-        nout = y.shape[1]
-    elif len(y.shape) == 1:
+    if len(y.shape) == 1 or (len(y.shape) == 2 and y.shape[1] == 1):
         multioutput = False
         nout = 1
+        y = y.reshape(-1)
+    elif len(y.shape) == 2:
+        multioutput = True
+        nout = y.shape[1]
     else:
         raise NotImplementedError("y shape not supported!")
 

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -728,7 +728,7 @@ def run_feature_selection(X, y, select_k_features):
 
 def get_hof(equation_file=None, n_features=None, variable_names=None,
             extra_sympy_mappings=None, output_jax_format=False,
-            multioutput=False, nout=None, **kwargs):
+            multioutput=None, nout=None, **kwargs):
     """Get the equations from a hall of fame file. If no arguments
     entered, the ones used previously from a call to PySR will be used."""
 

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -411,9 +411,7 @@ def _cmd_runner(command, **kwargs):
                                 .replace('\\r',      '\r')
                                 .encode(sys.stdout.encoding, errors='replace'))
 
-            print(decoded_line, end='')
-
-
+            sys.stdout.buffer.write(decoded_line)
 
         process.stdout.close()
         process.wait()

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -821,35 +821,39 @@ def best_row(equations=None):
     """Return the best row of a hall of fame file using the score column.
     By default this uses the last equation file.
     """
-    if equations is None: all_eqs = get_hof()
-    if isinstance(all_eqs, list):
-        return [equations[j].iloc[np.argmax(equations[j]['score'])] for j in range(len(all_eqs))]
+    if equations is None: equations = get_hof()
+    if isinstance(equations, list):
+        return [eq.iloc[np.argmax(eq['score'])] for eq in equations]
     else:
-        best_idx = np.argmax(equations['score'])
-        return equations.iloc[best_idx]
+        return equations.iloc[np.argmax(equations['score'])]
 
 def best_tex(equations=None):
     """Return the equation with the best score, in latex format
     By default this uses the last equation file.
     """
     if equations is None: equations = get_hof()
-    best_sympy = best_row(equations)['sympy_format']
-    return sympy.latex(best_sympy.simplify())
+    if isinstance(equations, list):
+        return [sympy.latex(best_row(eq)['sympy_format'].simplify()) for eq in equations]
+    else:
+        return sympy.latex(best_row(equations)['sympy_format'].simplify())
 
 def best(equations=None):
     """Return the equation with the best score, in sympy format.
     By default this uses the last equation file.
     """
     if equations is None: equations = get_hof()
-    best_sympy = best_row(equations)['sympy_format']
-    return best_sympy.simplify()
+        return [best_row(eq)['sympy_format'].simplify() for eq in equations]
+    else:
+        return best_row(equations)['sympy_format'].simplify()
 
 def best_callable(equations=None):
     """Return the equation with the best score, in callable format.
     By default this uses the last equation file.
     """
     if equations is None: equations = get_hof()
-    return best_row(equations)['lambda_format']
+        return [best_row(eq)['lambda_format'] for eq in equations]
+    else:
+        return best_row(equations)['lambda_format']
 
 def _escape_filename(filename):
     """Turns a file into a string representation with correctly escaped backslashes"""

--- a/test/test.py
+++ b/test/test.py
@@ -17,14 +17,15 @@ equations = pysr(X, y, **default_test_kwargs)
 print(equations)
 assert equations.iloc[-1]['MSE'] < 1e-4
 
-print("Test 2 - test custom operator")
-y = X[:, 0]**2
+print("Test 2 - test custom operator, and multiple outputs")
+y = X[:, [0, 1]]**2
 equations = pysr(X, y,
                  unary_operators=["sq(x) = x^2"], binary_operators=["plus"],
                  extra_sympy_mappings={'square': lambda x: x**2},
                  **default_test_kwargs)
 print(equations)
-assert equations.iloc[-1]['MSE'] < 1e-4
+assert equations[0].iloc[-1]['MSE'] < 1e-4
+assert equations[1].iloc[-1]['MSE'] < 1e-4
 
 X = np.random.randn(100, 1)
 y = X[:, 0] + 3.0


### PR DESCRIPTION
This will allow one to pass a matrix for y, and the backend will batch an equation search, and return equations for each output. This is much faster than running PySR once for every output, and of course, more convenient.

Fixes #35 and #45.