### PR TITLE
PyTorch export

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,16 +61,22 @@ jobs:
             python setup.py install
       - name: "Install Coverage tool"
         run: pip install coverage coveralls
+      - name: "Run tests"
+        run: coverage run --source=pysr --omit='*/feynman_problems.py' -m unittest test.test
+        shell: bash
       - name: "Install JAX"
         if: matrix.os != 'windows-latest'
         run: pip install jax jaxlib # (optional import)
         shell: bash
-      - name: "Run tests"
-        run: coverage run --source=pysr --omit='*/feynman_problems.py' -m unittest test.test
-        shell: bash
       - name: "Run JAX tests"
         if: matrix.os != 'windows-latest'
         run: coverage run --append --source=pysr --omit='*/feynman_problems.py' -m unittest test.test_jax
+        shell: bash
+      - name: "Install Torch"
+        run: pip install torch # (optional import)
+        shell: bash
+      - name: "Run Torch tests"
+        run: coverage run --append --source=pysr --omit='*/feynman_problems.py' -m unittest test.test_torch
         shell: bash
       - name: Coveralls
         env:

--- a/pysr/__init__.py
+++ b/pysr/__init__.py
@@ -1,3 +1,3 @@
 from .sr import pysr, get_hof, best, best_tex, best_callable, best_row
 from .feynman_problems import Problem, FeynmanProblem
-from .export import sympy2jax
+from .export_jax import sympy2jax

--- a/pysr/__init__.py
+++ b/pysr/__init__.py
@@ -1,4 +1,2 @@
 from .sr import pysr, get_hof, best, best_tex, best_callable, best_row
 from .feynman_problems import Problem, FeynmanProblem
-from .export_jax import sympy2jax
-from .export_torch import sympy2torch

--- a/pysr/__init__.py
+++ b/pysr/__init__.py
@@ -1,3 +1,4 @@
 from .sr import pysr, get_hof, best, best_tex, best_callable, best_row
 from .feynman_problems import Problem, FeynmanProblem
 from .export_jax import sympy2jax
+from .export_torch import sympy2torch

--- a/pysr/__init__.py
+++ b/pysr/__init__.py
@@ -1,2 +1,4 @@
 from .sr import pysr, get_hof, best, best_tex, best_callable, best_row
 from .feynman_problems import Problem, FeynmanProblem
+from .export_jax import sympy2jax
+from .export_torch import sympy2torch

--- a/pysr/export_jax.py
+++ b/pysr/export_jax.py
@@ -2,9 +2,6 @@ import functools as ft
 import sympy
 import string
 import random
-import jax
-from jax import numpy as jnp
-from jax.scipy import special as jsp
 
 # Special since need to reduce arguments.
 MUL = 0
@@ -53,6 +50,7 @@ _jnp_func_lookup = {
     sympy.Mod: "jnp.mod",
 }
 
+
 def sympy2jaxtext(expr, parameters, symbols_in):
     if issubclass(expr.func, sympy.Float):
         parameters.append(float(expr))
@@ -70,6 +68,27 @@ def sympy2jaxtext(expr, parameters, symbols_in):
             return ' + '.join(['(' + arg + ')' for arg in args])
         else:
             return f'{_func}({", ".join(args)})'
+
+
+jax_initialized = False
+jax = None
+jnp = None
+jsp = None
+
+def _initialize_jax():
+    global jax_initialized
+    global jax
+    global jnp
+    global jsp
+
+    if not jax_initialized:
+        import jax as _jax
+        from jax import numpy as _jnp
+        from jax.scipy import special as _jsp
+        jax = _jax
+        jnp = _jnp
+        jsp = _jsp
+
 
 def sympy2jax(expression, symbols_in):
     """Returns a function f and its parameters;
@@ -142,6 +161,12 @@ def sympy2jax(expression, symbols_in):
         #                3.5427954 , -2.7479894 ], dtype=float32)
         ```
     """
+    _initialize_jax()
+    global jax_initialized
+    global jax
+    global jnp
+    global jsp
+
     parameters = []
     functional_form_text = sympy2jaxtext(expression, parameters, symbols_in)
     hash_string = 'A_' + str(abs(hash(str(expression) + str(symbols_in))))

--- a/pysr/export_jax.py
+++ b/pysr/export_jax.py
@@ -2,60 +2,56 @@ import functools as ft
 import sympy
 import string
 import random
-
-try:
-    import jax
-    from jax import numpy as jnp
-    from jax.scipy import special as jsp
+import jax
+from jax import numpy as jnp
+from jax.scipy import special as jsp
 
 # Special since need to reduce arguments.
-    MUL = 0
-    ADD = 1
+MUL = 0
+ADD = 1
 
-    _jnp_func_lookup = {
-        sympy.Mul: MUL,
-        sympy.Add: ADD,
-        sympy.div: "jnp.div",
-        sympy.Abs: "jnp.abs",
-        sympy.sign: "jnp.sign",
-        # Note: May raise error for ints.
-        sympy.ceiling: "jnp.ceil",
-        sympy.floor: "jnp.floor",
-        sympy.log: "jnp.log",
-        sympy.exp: "jnp.exp",
-        sympy.sqrt: "jnp.sqrt",
-        sympy.cos: "jnp.cos",
-        sympy.acos: "jnp.acos",
-        sympy.sin: "jnp.sin",
-        sympy.asin: "jnp.asin",
-        sympy.tan: "jnp.tan",
-        sympy.atan: "jnp.atan",
-        sympy.atan2: "jnp.atan2",
-        # Note: Also may give NaN for complex results.
-        sympy.cosh: "jnp.cosh",
-        sympy.acosh: "jnp.acosh",
-        sympy.sinh: "jnp.sinh",
-        sympy.asinh: "jnp.asinh",
-        sympy.tanh: "jnp.tanh",
-        sympy.atanh: "jnp.atanh",
-        sympy.Pow: "jnp.power",
-        sympy.re: "jnp.real",
-        sympy.im: "jnp.imag",
-        sympy.arg: "jnp.angle",
-        # Note: May raise error for ints and complexes
-        sympy.erf: "jsp.erf",
-        sympy.erfc: "jsp.erfc",
-        sympy.LessThan: "jnp.less",
-        sympy.GreaterThan: "jnp.greater",
-        sympy.And: "jnp.logical_and",
-        sympy.Or: "jnp.logical_or",
-        sympy.Not: "jnp.logical_not",
-        sympy.Max: "jnp.max",
-        sympy.Min: "jnp.min",
-        sympy.Mod: "jnp.mod",
-    }
-except ImportError:
-    ...
+_jnp_func_lookup = {
+    sympy.Mul: MUL,
+    sympy.Add: ADD,
+    sympy.div: "jnp.div",
+    sympy.Abs: "jnp.abs",
+    sympy.sign: "jnp.sign",
+    # Note: May raise error for ints.
+    sympy.ceiling: "jnp.ceil",
+    sympy.floor: "jnp.floor",
+    sympy.log: "jnp.log",
+    sympy.exp: "jnp.exp",
+    sympy.sqrt: "jnp.sqrt",
+    sympy.cos: "jnp.cos",
+    sympy.acos: "jnp.acos",
+    sympy.sin: "jnp.sin",
+    sympy.asin: "jnp.asin",
+    sympy.tan: "jnp.tan",
+    sympy.atan: "jnp.atan",
+    sympy.atan2: "jnp.atan2",
+    # Note: Also may give NaN for complex results.
+    sympy.cosh: "jnp.cosh",
+    sympy.acosh: "jnp.acosh",
+    sympy.sinh: "jnp.sinh",
+    sympy.asinh: "jnp.asinh",
+    sympy.tanh: "jnp.tanh",
+    sympy.atanh: "jnp.atanh",
+    sympy.Pow: "jnp.power",
+    sympy.re: "jnp.real",
+    sympy.im: "jnp.imag",
+    sympy.arg: "jnp.angle",
+    # Note: May raise error for ints and complexes
+    sympy.erf: "jsp.erf",
+    sympy.erfc: "jsp.erfc",
+    sympy.LessThan: "jnp.less",
+    sympy.GreaterThan: "jnp.greater",
+    sympy.And: "jnp.logical_and",
+    sympy.Or: "jnp.logical_or",
+    sympy.Not: "jnp.logical_not",
+    sympy.Max: "jnp.max",
+    sympy.Min: "jnp.min",
+    sympy.Mod: "jnp.mod",
+}
 
 def sympy2jaxtext(expr, parameters, symbols_in):
     if issubclass(expr.func, sympy.Float):

--- a/pysr/export_jax.py
+++ b/pysr/export_jax.py
@@ -75,7 +75,7 @@ def sympy2jaxtext(expr, parameters, symbols_in):
         else:
             return f'{_func}({", ".join(args)})'
 
-def sympy2jax(equation, symbols_in):
+def sympy2jax(expression, symbols_in):
     """Returns a function f and its parameters;
     the function takes an input matrix, and a list of arguments:
             f(X, parameters)
@@ -147,8 +147,8 @@ def sympy2jax(equation, symbols_in):
         ```
     """
     parameters = []
-    functional_form_text = sympy2jaxtext(equation, parameters, symbols_in)
-    hash_string = 'A_' + str(abs(hash(str(equation) + str(symbols_in))))
+    functional_form_text = sympy2jaxtext(expression, parameters, symbols_in)
+    hash_string = 'A_' + str(abs(hash(str(expression) + str(symbols_in))))
     text = f"def {hash_string}(X, parameters):\n"
     text += "    return "
     text += functional_form_text

--- a/pysr/export_torch.py
+++ b/pysr/export_torch.py
@@ -84,6 +84,7 @@ def _initialize_torch():
         }
 
         class _Node(torch.nn.Module):
+            """SympyTorch code from https://github.com/patrick-kidger/sympytorch"""
             def __init__(self, *, expr, _memodict, _func_lookup, **kwargs):
                 super().__init__(**kwargs)
 
@@ -134,6 +135,7 @@ def _initialize_torch():
 
 
         class SingleSymPyModule(torch.nn.Module):
+            """SympyTorch code from https://github.com/patrick-kidger/sympytorch"""
             def __init__(self, expression, symbols_in,
                     extra_funcs=None, **kwargs):
                 super().__init__(**kwargs)
@@ -149,10 +151,6 @@ def _initialize_torch():
 
             def __repr__(self):
                 return f"{type(self).__name__}(expression={self._expression_string})"
-
-            def sympy(self):
-                _memodict = {}
-                return self._node.sympy(_memodict)
 
             def forward(self, X):
                 symbols = {symbol: X[:, i]

--- a/pysr/export_torch.py
+++ b/pysr/export_torch.py
@@ -8,7 +8,6 @@ import functools as ft
 import sympy
 import torch
 
-
 def _reduce(fn):
     def fn_(*args):
         return ft.reduce(fn, args)
@@ -66,7 +65,6 @@ _global_func_lookup = {
     # Note: May raise error for integer matrices.
     sympy.Determinant: torch.det,
 }
-
 
 class _Node(torch.nn.Module):
     def __init__(self, *, expr, _memodict, _func_lookup, **kwargs):

--- a/pysr/export_torch.py
+++ b/pysr/export_torch.py
@@ -160,7 +160,7 @@ def _initialize_torch():
                 return self._node(symbols)
 
 
-def sympy2torch(expression, symbols_in):
+def sympy2torch(expression, symbols_in, extra_torch_mappings=None):
     """Returns a module for a given sympy expression with trainable parameters;
 
     This function will assume the input to the module is a matrix X, where
@@ -170,4 +170,4 @@ def sympy2torch(expression, symbols_in):
 
     _initialize_torch()
 
-    return SingleSymPyModule(expression, symbols_in)
+    return SingleSymPyModule(expression, symbols_in, extra_funcs=extra_torch_mappings)

--- a/pysr/export_torch.py
+++ b/pysr/export_torch.py
@@ -1,0 +1,172 @@
+#####
+# From https://github.com/patrick-kidger/sympytorch
+# Copied here to allow PySR-specific tweaks
+#####
+
+import collections as co
+import functools as ft
+import sympy
+import torch
+
+
+def _reduce(fn):
+    def fn_(*args):
+        return ft.reduce(fn, args)
+    return fn_
+
+
+_global_func_lookup = {
+    sympy.Mul: _reduce(torch.mul),
+    sympy.Add: _reduce(torch.add),
+    sympy.div: torch.div,
+    sympy.Abs: torch.abs,
+    sympy.sign: torch.sign,
+    # Note: May raise error for ints.
+    sympy.ceiling: torch.ceil,
+    sympy.floor: torch.floor,
+    sympy.log: torch.log,
+    sympy.exp: torch.exp,
+    sympy.sqrt: torch.sqrt,
+    sympy.cos: torch.cos,
+    sympy.acos: torch.acos,
+    sympy.sin: torch.sin,
+    sympy.asin: torch.asin,
+    sympy.tan: torch.tan,
+    sympy.atan: torch.atan,
+    sympy.atan2: torch.atan2,
+    # Note: May give NaN for complex results.
+    sympy.cosh: torch.cosh,
+    sympy.acosh: torch.acosh,
+    sympy.sinh: torch.sinh,
+    sympy.asinh: torch.asinh,
+    sympy.tanh: torch.tanh,
+    sympy.atanh: torch.atanh,
+    sympy.Pow: torch.pow,
+    sympy.re: torch.real,
+    sympy.im: torch.imag,
+    sympy.arg: torch.angle,
+    # Note: May raise error for ints and complexes
+    sympy.erf: torch.erf,
+    sympy.loggamma: torch.lgamma,
+    sympy.Eq: torch.eq,
+    sympy.Ne: torch.ne,
+    sympy.StrictGreaterThan: torch.gt,
+    sympy.StrictLessThan: torch.lt,
+    sympy.LessThan: torch.le,
+    sympy.GreaterThan: torch.ge,
+    sympy.And: torch.logical_and,
+    sympy.Or: torch.logical_or,
+    sympy.Not: torch.logical_not,
+    sympy.Max: torch.max,
+    sympy.Min: torch.min,
+    # Matrices
+    sympy.MatAdd: torch.add,
+    sympy.HadamardProduct: torch.mul,
+    sympy.Trace: torch.trace,
+    # Note: May raise error for integer matrices.
+    sympy.Determinant: torch.det,
+}
+
+
+class _Node(torch.nn.Module):
+    def __init__(self, *, expr, _memodict, _func_lookup, **kwargs):
+        super().__init__(**kwargs)
+
+        self._sympy_func = expr.func
+
+        if issubclass(expr.func, sympy.Float):
+            self._value = torch.nn.Parameter(torch.tensor(float(expr)))
+            self._torch_func = lambda: self._value
+            self._args = ()
+        elif issubclass(expr.func, sympy.UnevaluatedExpr):
+            if len(expr.args) != 1 or not issubclass(expr.args[0].func, sympy.Float):
+                raise ValueError("UnevaluatedExpr should only be used to wrap floats.")
+            self.register_buffer('_value', torch.tensor(float(expr.args[0])))
+            self._torch_func = lambda: self._value
+            self._args = ()
+        elif issubclass(expr.func, sympy.Integer):
+            # Can get here if expr is one of the Integer special cases,
+            # e.g. NegativeOne
+            self._value = int(expr)
+            self._torch_func = lambda: self._value
+            self._args = ()
+        elif issubclass(expr.func, sympy.Symbol):
+            self._name = expr.name
+            self._torch_func = lambda value: value
+            self._args = ((lambda memodict: memodict[expr.name]),)
+        else:
+            self._torch_func = _func_lookup[expr.func]
+            args = []
+            for arg in expr.args:
+                try:
+                    arg_ = _memodict[arg]
+                except KeyError:
+                    arg_ = type(self)(expr=arg, _memodict=_memodict, _func_lookup=_func_lookup, **kwargs)
+                    _memodict[arg] = arg_
+                args.append(arg_)
+            self._args = torch.nn.ModuleList(args)
+
+    def sympy(self, _memodict):
+        if issubclass(self._sympy_func, sympy.Float):
+            return self._sympy_func(self._value.item())
+        elif issubclass(self._sympy_func, sympy.UnevaluatedExpr):
+            return self._sympy_func(self._value.item())
+        elif issubclass(self._sympy_func, sympy.Integer):
+            return self._sympy_func(self._value)
+        elif issubclass(self._sympy_func, sympy.Symbol):
+            return self._sympy_func(self._name)
+        else:
+            if issubclass(self._sympy_func, (sympy.Min, sympy.Max)):
+                evaluate = False
+            else:
+                evaluate = True
+            args = []
+            for arg in self._args:
+                try:
+                    arg_ = _memodict[arg]
+                except KeyError:
+                    arg_ = arg.sympy(_memodict)
+                    _memodict[arg] = arg_
+                args.append(arg_)
+            return self._sympy_func(*args, evaluate=evaluate)
+
+    def forward(self, memodict):
+        args = []
+        for arg in self._args:
+            try:
+                arg_ = memodict[arg]
+            except KeyError:
+                arg_ = arg(memodict)
+                memodict[arg] = arg_
+            args.append(arg_)
+        return self._torch_func(*args)
+
+
+class SingleSymPyModule(torch.nn.Module):
+    def __init__(self, expression, symbols_in,
+            extra_funcs=None, **kwargs):
+        super().__init__(**kwargs)
+        
+        if extra_funcs is None:
+            extra_funcs = {}
+        _func_lookup = co.ChainMap(_global_func_lookup, extra_funcs)
+
+        _memodict = {}
+        self._node = _Node(expr=expression, _memodict=_memodict, _func_lookup=_func_lookup)
+        self._expression_string = str(expression)
+        self.symbols_in = [str(symbol) for symbol in symbols_in]
+
+    def __repr__(self):
+        return f"{type(self).__name__}(expression={self._expression_string})"
+
+    def sympy(self):
+        _memodict = {}
+        return self._node.sympy(_memodict)
+
+    def forward(self, X):
+        symbols = {symbol: X[:, i]
+                   for i, symbol in enumerate(self.symbols_in)}
+        return self._node(symbols)
+
+def sympy2torch(expression, symbols_in):
+    return SingleSymPyModule(expression, symbols_in)

--- a/pysr/export_torch.py
+++ b/pysr/export_torch.py
@@ -185,8 +185,11 @@ def _initialize_torch():
 
 
 def sympy2torch(expression, symbols_in):
-    global torch
-    global _Node
+    """Returns a module for a given sympy expression with trainable parameters;
+
+    This function will assume the input to the module is a matrix X, where
+        each column corresponds to each symbol you pass in `symbols_in`.
+    """
     global SingleSymPyModule
 
     _initialize_torch()

--- a/pysr/export_torch.py
+++ b/pysr/export_torch.py
@@ -121,30 +121,6 @@ def _initialize_torch():
                         args.append(arg_)
                     self._args = torch.nn.ModuleList(args)
 
-            def sympy(self, _memodict):
-                if issubclass(self._sympy_func, sympy.Float):
-                    return self._sympy_func(self._value.item())
-                elif issubclass(self._sympy_func, sympy.UnevaluatedExpr):
-                    return self._sympy_func(self._value.item())
-                elif issubclass(self._sympy_func, sympy.Integer):
-                    return self._sympy_func(self._value)
-                elif issubclass(self._sympy_func, sympy.Symbol):
-                    return self._sympy_func(self._name)
-                else:
-                    if issubclass(self._sympy_func, (sympy.Min, sympy.Max)):
-                        evaluate = False
-                    else:
-                        evaluate = True
-                    args = []
-                    for arg in self._args:
-                        try:
-                            arg_ = _memodict[arg]
-                        except KeyError:
-                            arg_ = arg.sympy(_memodict)
-                            _memodict[arg] = arg_
-                        args.append(arg_)
-                    return self._sympy_func(*args, evaluate=evaluate)
-
             def forward(self, memodict):
                 args = []
                 for arg in self._args:

--- a/pysr/export_torch.py
+++ b/pysr/export_torch.py
@@ -6,165 +6,189 @@
 import collections as co
 import functools as ft
 import sympy
-import torch
 
 def _reduce(fn):
     def fn_(*args):
         return ft.reduce(fn, args)
     return fn_
 
+torch_initialized = False
+torch = None
+_global_func_lookup = None
+_Node = None
+SingleSymPyModule = None
 
-_global_func_lookup = {
-    sympy.Mul: _reduce(torch.mul),
-    sympy.Add: _reduce(torch.add),
-    sympy.div: torch.div,
-    sympy.Abs: torch.abs,
-    sympy.sign: torch.sign,
-    # Note: May raise error for ints.
-    sympy.ceiling: torch.ceil,
-    sympy.floor: torch.floor,
-    sympy.log: torch.log,
-    sympy.exp: torch.exp,
-    sympy.sqrt: torch.sqrt,
-    sympy.cos: torch.cos,
-    sympy.acos: torch.acos,
-    sympy.sin: torch.sin,
-    sympy.asin: torch.asin,
-    sympy.tan: torch.tan,
-    sympy.atan: torch.atan,
-    sympy.atan2: torch.atan2,
-    # Note: May give NaN for complex results.
-    sympy.cosh: torch.cosh,
-    sympy.acosh: torch.acosh,
-    sympy.sinh: torch.sinh,
-    sympy.asinh: torch.asinh,
-    sympy.tanh: torch.tanh,
-    sympy.atanh: torch.atanh,
-    sympy.Pow: torch.pow,
-    sympy.re: torch.real,
-    sympy.im: torch.imag,
-    sympy.arg: torch.angle,
-    # Note: May raise error for ints and complexes
-    sympy.erf: torch.erf,
-    sympy.loggamma: torch.lgamma,
-    sympy.Eq: torch.eq,
-    sympy.Ne: torch.ne,
-    sympy.StrictGreaterThan: torch.gt,
-    sympy.StrictLessThan: torch.lt,
-    sympy.LessThan: torch.le,
-    sympy.GreaterThan: torch.ge,
-    sympy.And: torch.logical_and,
-    sympy.Or: torch.logical_or,
-    sympy.Not: torch.logical_not,
-    sympy.Max: torch.max,
-    sympy.Min: torch.min,
-    # Matrices
-    sympy.MatAdd: torch.add,
-    sympy.HadamardProduct: torch.mul,
-    sympy.Trace: torch.trace,
-    # Note: May raise error for integer matrices.
-    sympy.Determinant: torch.det,
-}
+def _initialize_torch():
+    global torch_initialized
+    global torch
+    global _global_func_lookup
+    global _Node
+    global SingleSymPyModule
 
-class _Node(torch.nn.Module):
-    def __init__(self, *, expr, _memodict, _func_lookup, **kwargs):
-        super().__init__(**kwargs)
+    # Way to lazy load torch, only if this is called,
+    # but still allow this module to be loaded in __init__
+    if not torch_initialized:
+        import torch as _torch
+        torch = _torch
 
-        self._sympy_func = expr.func
+        _global_func_lookup = {
+            sympy.Mul: _reduce(torch.mul),
+            sympy.Add: _reduce(torch.add),
+            sympy.div: torch.div,
+            sympy.Abs: torch.abs,
+            sympy.sign: torch.sign,
+            # Note: May raise error for ints.
+            sympy.ceiling: torch.ceil,
+            sympy.floor: torch.floor,
+            sympy.log: torch.log,
+            sympy.exp: torch.exp,
+            sympy.sqrt: torch.sqrt,
+            sympy.cos: torch.cos,
+            sympy.acos: torch.acos,
+            sympy.sin: torch.sin,
+            sympy.asin: torch.asin,
+            sympy.tan: torch.tan,
+            sympy.atan: torch.atan,
+            sympy.atan2: torch.atan2,
+            # Note: May give NaN for complex results.
+            sympy.cosh: torch.cosh,
+            sympy.acosh: torch.acosh,
+            sympy.sinh: torch.sinh,
+            sympy.asinh: torch.asinh,
+            sympy.tanh: torch.tanh,
+            sympy.atanh: torch.atanh,
+            sympy.Pow: torch.pow,
+            sympy.re: torch.real,
+            sympy.im: torch.imag,
+            sympy.arg: torch.angle,
+            # Note: May raise error for ints and complexes
+            sympy.erf: torch.erf,
+            sympy.loggamma: torch.lgamma,
+            sympy.Eq: torch.eq,
+            sympy.Ne: torch.ne,
+            sympy.StrictGreaterThan: torch.gt,
+            sympy.StrictLessThan: torch.lt,
+            sympy.LessThan: torch.le,
+            sympy.GreaterThan: torch.ge,
+            sympy.And: torch.logical_and,
+            sympy.Or: torch.logical_or,
+            sympy.Not: torch.logical_not,
+            sympy.Max: torch.max,
+            sympy.Min: torch.min,
+            # Matrices
+            sympy.MatAdd: torch.add,
+            sympy.HadamardProduct: torch.mul,
+            sympy.Trace: torch.trace,
+            # Note: May raise error for integer matrices.
+            sympy.Determinant: torch.det,
+        }
 
-        if issubclass(expr.func, sympy.Float):
-            self._value = torch.nn.Parameter(torch.tensor(float(expr)))
-            self._torch_func = lambda: self._value
-            self._args = ()
-        elif issubclass(expr.func, sympy.UnevaluatedExpr):
-            if len(expr.args) != 1 or not issubclass(expr.args[0].func, sympy.Float):
-                raise ValueError("UnevaluatedExpr should only be used to wrap floats.")
-            self.register_buffer('_value', torch.tensor(float(expr.args[0])))
-            self._torch_func = lambda: self._value
-            self._args = ()
-        elif issubclass(expr.func, sympy.Integer):
-            # Can get here if expr is one of the Integer special cases,
-            # e.g. NegativeOne
-            self._value = int(expr)
-            self._torch_func = lambda: self._value
-            self._args = ()
-        elif issubclass(expr.func, sympy.Symbol):
-            self._name = expr.name
-            self._torch_func = lambda value: value
-            self._args = ((lambda memodict: memodict[expr.name]),)
-        else:
-            self._torch_func = _func_lookup[expr.func]
-            args = []
-            for arg in expr.args:
-                try:
-                    arg_ = _memodict[arg]
-                except KeyError:
-                    arg_ = type(self)(expr=arg, _memodict=_memodict, _func_lookup=_func_lookup, **kwargs)
-                    _memodict[arg] = arg_
-                args.append(arg_)
-            self._args = torch.nn.ModuleList(args)
+        class _Node(torch.nn.Module):
+            def __init__(self, *, expr, _memodict, _func_lookup, **kwargs):
+                super().__init__(**kwargs)
 
-    def sympy(self, _memodict):
-        if issubclass(self._sympy_func, sympy.Float):
-            return self._sympy_func(self._value.item())
-        elif issubclass(self._sympy_func, sympy.UnevaluatedExpr):
-            return self._sympy_func(self._value.item())
-        elif issubclass(self._sympy_func, sympy.Integer):
-            return self._sympy_func(self._value)
-        elif issubclass(self._sympy_func, sympy.Symbol):
-            return self._sympy_func(self._name)
-        else:
-            if issubclass(self._sympy_func, (sympy.Min, sympy.Max)):
-                evaluate = False
-            else:
-                evaluate = True
-            args = []
-            for arg in self._args:
-                try:
-                    arg_ = _memodict[arg]
-                except KeyError:
-                    arg_ = arg.sympy(_memodict)
-                    _memodict[arg] = arg_
-                args.append(arg_)
-            return self._sympy_func(*args, evaluate=evaluate)
+                self._sympy_func = expr.func
 
-    def forward(self, memodict):
-        args = []
-        for arg in self._args:
-            try:
-                arg_ = memodict[arg]
-            except KeyError:
-                arg_ = arg(memodict)
-                memodict[arg] = arg_
-            args.append(arg_)
-        return self._torch_func(*args)
+                if issubclass(expr.func, sympy.Float):
+                    self._value = torch.nn.Parameter(torch.tensor(float(expr)))
+                    self._torch_func = lambda: self._value
+                    self._args = ()
+                elif issubclass(expr.func, sympy.UnevaluatedExpr):
+                    if len(expr.args) != 1 or not issubclass(expr.args[0].func, sympy.Float):
+                        raise ValueError("UnevaluatedExpr should only be used to wrap floats.")
+                    self.register_buffer('_value', torch.tensor(float(expr.args[0])))
+                    self._torch_func = lambda: self._value
+                    self._args = ()
+                elif issubclass(expr.func, sympy.Integer):
+                    # Can get here if expr is one of the Integer special cases,
+                    # e.g. NegativeOne
+                    self._value = int(expr)
+                    self._torch_func = lambda: self._value
+                    self._args = ()
+                elif issubclass(expr.func, sympy.Symbol):
+                    self._name = expr.name
+                    self._torch_func = lambda value: value
+                    self._args = ((lambda memodict: memodict[expr.name]),)
+                else:
+                    self._torch_func = _func_lookup[expr.func]
+                    args = []
+                    for arg in expr.args:
+                        try:
+                            arg_ = _memodict[arg]
+                        except KeyError:
+                            arg_ = type(self)(expr=arg, _memodict=_memodict, _func_lookup=_func_lookup, **kwargs)
+                            _memodict[arg] = arg_
+                        args.append(arg_)
+                    self._args = torch.nn.ModuleList(args)
+
+            def sympy(self, _memodict):
+                if issubclass(self._sympy_func, sympy.Float):
+                    return self._sympy_func(self._value.item())
+                elif issubclass(self._sympy_func, sympy.UnevaluatedExpr):
+                    return self._sympy_func(self._value.item())
+                elif issubclass(self._sympy_func, sympy.Integer):
+                    return self._sympy_func(self._value)
+                elif issubclass(self._sympy_func, sympy.Symbol):
+                    return self._sympy_func(self._name)
+                else:
+                    if issubclass(self._sympy_func, (sympy.Min, sympy.Max)):
+                        evaluate = False
+                    else:
+                        evaluate = True
+                    args = []
+                    for arg in self._args:
+                        try:
+                            arg_ = _memodict[arg]
+                        except KeyError:
+                            arg_ = arg.sympy(_memodict)
+                            _memodict[arg] = arg_
+                        args.append(arg_)
+                    return self._sympy_func(*args, evaluate=evaluate)
+
+            def forward(self, memodict):
+                args = []
+                for arg in self._args:
+                    try:
+                        arg_ = memodict[arg]
+                    except KeyError:
+                        arg_ = arg(memodict)
+                        memodict[arg] = arg_
+                    args.append(arg_)
+                return self._torch_func(*args)
 
 
-class SingleSymPyModule(torch.nn.Module):
-    def __init__(self, expression, symbols_in,
-            extra_funcs=None, **kwargs):
-        super().__init__(**kwargs)
-        
-        if extra_funcs is None:
-            extra_funcs = {}
-        _func_lookup = co.ChainMap(_global_func_lookup, extra_funcs)
+        class SingleSymPyModule(torch.nn.Module):
+            def __init__(self, expression, symbols_in,
+                    extra_funcs=None, **kwargs):
+                super().__init__(**kwargs)
+                
+                if extra_funcs is None:
+                    extra_funcs = {}
+                _func_lookup = co.ChainMap(_global_func_lookup, extra_funcs)
 
-        _memodict = {}
-        self._node = _Node(expr=expression, _memodict=_memodict, _func_lookup=_func_lookup)
-        self._expression_string = str(expression)
-        self.symbols_in = [str(symbol) for symbol in symbols_in]
+                _memodict = {}
+                self._node = _Node(expr=expression, _memodict=_memodict, _func_lookup=_func_lookup)
+                self._expression_string = str(expression)
+                self.symbols_in = [str(symbol) for symbol in symbols_in]
 
-    def __repr__(self):
-        return f"{type(self).__name__}(expression={self._expression_string})"
+            def __repr__(self):
+                return f"{type(self).__name__}(expression={self._expression_string})"
 
-    def sympy(self):
-        _memodict = {}
-        return self._node.sympy(_memodict)
+            def sympy(self):
+                _memodict = {}
+                return self._node.sympy(_memodict)
 
-    def forward(self, X):
-        symbols = {symbol: X[:, i]
-                   for i, symbol in enumerate(self.symbols_in)}
-        return self._node(symbols)
+            def forward(self, X):
+                symbols = {symbol: X[:, i]
+                           for i, symbol in enumerate(self.symbols_in)}
+                return self._node(symbols)
+
 
 def sympy2torch(expression, symbols_in):
+    global torch
+    global _Node
+    global SingleSymPyModule
+
+    _initialize_torch()
+
     return SingleSymPyModule(expression, symbols_in)

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -800,8 +800,8 @@ def get_hof(equation_file=None, n_features=None, variable_names=None,
 =======
             if output_torch_format:
                 from .export_torch import sympy2torch
-                func, params = sympy2torch(eqn, sympy_symbols)
-                torch_format.append({'callable': func, 'parameters': params})
+                module = sympy2torch(eqn, sympy_symbols)
+                torch_format.append(module)
             lambda_format.append(lambdify(sympy_symbols, eqn))
 >>>>>>> 6ba697f (Add torch format output; dont import jax/torch by default)
             curMSE = output.loc[i, 'MSE']

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -102,6 +102,8 @@ def pysr(X, y, weights=None,
          perturbationFactor=1.0,
          timeout=None,
          extra_sympy_mappings=None,
+         extra_torch_mappings=None,
+         extra_jax_mappings=None,
          equation_file=None,
          verbosity=1e9,
          progress=True,
@@ -336,6 +338,8 @@ def pysr(X, y, weights=None,
                  weightSimplify=weightSimplify,
                  constraints=constraints,
                  extra_sympy_mappings=extra_sympy_mappings,
+                 extra_jax_mappings=extra_jax_mappings,
+                 extra_torch_mappings=extra_torch_mappings,
                  julia_project=julia_project, loss=loss,
                  output_jax_format=output_jax_format,
                  output_torch_format=output_torch_format,
@@ -730,6 +734,7 @@ def run_feature_selection(X, y, select_k_features):
 def get_hof(equation_file=None, n_features=None, variable_names=None,
             extra_sympy_mappings=None, output_jax_format=False,
             output_torch_format=False,
+            extra_jax_mappings=None, extra_torch_mappings=None,
             multioutput=None, nout=None, **kwargs):
     """Get the equations from a hall of fame file. If no arguments
     entered, the ones used previously from a call to PySR will be used."""
@@ -790,20 +795,22 @@ def get_hof(equation_file=None, n_features=None, variable_names=None,
         for i in range(len(output)):
             eqn = sympify(output.loc[i, 'Equation'], locals=local_sympy_mappings)
             sympy_format.append(eqn)
+
+            # Numpy:
+            lambda_format.append(CallableEquation(sympy_symbols, eqn))
+
+            # JAX:
             if output_jax_format:
                 from .export_jax import sympy2jax
                 func, params = sympy2jax(eqn, sympy_symbols)
                 jax_format.append({'callable': func, 'parameters': params})
-<<<<<<< HEAD
 
-            lambda_format.append(CallableEquation(sympy_symbols, eqn))
-=======
+            # Torch:
             if output_torch_format:
                 from .export_torch import sympy2torch
                 module = sympy2torch(eqn, sympy_symbols)
                 torch_format.append(module)
-            lambda_format.append(lambdify(sympy_symbols, eqn))
->>>>>>> 6ba697f (Add torch format output; dont import jax/torch by default)
+
             curMSE = output.loc[i, 'MSE']
             curComplexity = output.loc[i, 'Complexity']
 

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -722,10 +722,10 @@ def run_feature_selection(X, y, select_k_features):
         the k most important features in X, returning indices for those
         features as output."""
 
-    from sklearn.ensemble import RandomForestRegressor, GradientBoostingRegressor
+    from sklearn.ensemble import RandomForestRegressor
     from sklearn.feature_selection import SelectFromModel, SelectKBest
 
-    clf = GradientBoostingRegressor(n_estimators=100, learning_rate=0.1, max_depth=1, random_state=0, loss='ls') #RandomForestRegressor()
+    clf = RandomForestRegressor(n_estimators=100, max_depth=3, random_state=0)
     clf.fit(X, y)
     selector = SelectFromModel(clf, threshold=-np.inf,
             max_features=select_k_features, prefit=True)

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from datetime import datetime
 import warnings
 from .export_jax import sympy2jax
+from .export_torch import sympy2torch
 
 global_equation_file = 'hall_of_fame.csv'
 global_n_features = None

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -13,7 +13,7 @@ import shutil
 from pathlib import Path
 from datetime import datetime
 import warnings
-from .export import sympy2jax
+from .export_jax import sympy2jax
 
 global_equation_file = 'hall_of_fame.csv'
 global_n_features = None

--- a/test/test_jax.py
+++ b/test/test_jax.py
@@ -1,6 +1,6 @@
 import unittest
 import numpy as np
-from pysr import pysr, sympy2jax
+from pysr import sympy2jax
 from jax import numpy as jnp
 from jax import random
 from jax import grad

--- a/test/test_jax.py
+++ b/test/test_jax.py
@@ -1,6 +1,7 @@
 import unittest
 import numpy as np
-from pysr import sympy2jax
+from pysr import sympy2jax, get_hof
+import pandas as pd
 from jax import numpy as jnp
 from jax import random
 from jax import grad
@@ -15,3 +16,24 @@ class TestJAX(unittest.TestCase):
         true = 1.0 * jnp.cos(X[:, 0]) + X[:, 1]
         f, params = sympy2jax(cosx, [x, y, z])
         self.assertTrue(jnp.all(jnp.isclose(f(X, params), true)).item())
+    def test_pipeline(self):
+        X = np.random.randn(100, 2)
+        equations = pd.DataFrame({
+            'Equation': ['1.0', 'cos(x0)', 'square(cos(x0))'],
+            'MSE': [1.0, 0.1, 1e-5],
+            'Complexity': [1, 2, 3]
+            })
+
+        equations['Complexity MSE Equation'.split(' ')].to_csv(
+                'equation_file.csv.bkup', sep='|')
+
+        equations = get_hof(
+                'equation_file.csv', n_features=2, variables_names='x0 x1'.split(' '),
+                extra_sympy_mappings={}, output_jax_format=True,
+                multioutput=False, nout=1)
+
+        jformat = equations.iloc[-1].jax_format
+        np.testing.assert_almost_equal(
+                np.array(jformat['callable'](jnp.array(X), jformat['parameters'])),
+                np.square(np.cos(X[:, 0]))
+        )

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6,7 +6,7 @@ import sympy
 print("Test Torch 1 - test export")
 x, y, z = sympy.symbols('x y z')
 cosx = 1.0 * sympy.cos(x) + y
-X = torch.randn((1000, 2))
+X = torch.randn((1000, 3))
 true = 1.0 * torch.cos(X[:, 0]) + X[:, 1]
 torch_module = sympy2torch(cosx, [x, y, z])
 assert np.all(np.isclose(torch_module(X).detach().numpy(), true.detach().numpy()))

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1,0 +1,12 @@
+import numpy as np
+from pysr import sympy2torch
+import torch
+import sympy
+
+print("Test Torch 1 - test export")
+x, y, z = sympy.symbols('x y z')
+cosx = 1.0 * sympy.cos(x) + y
+X = torch.randn((1000, 2))
+true = 1.0 * torch.cos(X[:, 0]) + X[:, 1]
+torch_module = sympy2torch(cosx, [x, y, z])
+assert jnp.all(jnp.isclose(torch_module(X), true)).item()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -9,4 +9,4 @@ cosx = 1.0 * sympy.cos(x) + y
 X = torch.randn((1000, 2))
 true = 1.0 * torch.cos(X[:, 0]) + X[:, 1]
 torch_module = sympy2torch(cosx, [x, y, z])
-assert jnp.all(jnp.isclose(torch_module(X), true)).item()
+assert np.all(np.isclose(torch_module(X).detach().numpy(), true.detach().numpy()))

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -1,12 +1,16 @@
+import unittest
 import numpy as np
 from pysr import sympy2torch
 import torch
 import sympy
 
-print("Test Torch 1 - test export")
-x, y, z = sympy.symbols('x y z')
-cosx = 1.0 * sympy.cos(x) + y
-X = torch.randn((1000, 3))
-true = 1.0 * torch.cos(X[:, 0]) + X[:, 1]
-torch_module = sympy2torch(cosx, [x, y, z])
-assert np.all(np.isclose(torch_module(X).detach().numpy(), true.detach().numpy()))
+class TestTorch(unittest.TestCase):
+    def test_sympy2torch(self):
+        x, y, z = sympy.symbols('x y z')
+        cosx = 1.0 * sympy.cos(x) + y
+        X = torch.randn((1000, 3))
+        true = 1.0 * torch.cos(X[:, 0]) + X[:, 1]
+        torch_module = sympy2torch(cosx, [x, y, z])
+        self.assertTrue(
+                np.all(np.isclose(torch_module(X).detach().numpy(), true.detach().numpy()))
+        )


### PR DESCRIPTION
This uses (a slightly-modified version of) @patrick-kidger's [sympytorch](https://github.com/patrick-kidger/sympytorch) to export discovered equations to PyTorch. Parameters in the module are set to the default as found by PySR, but are trainable.

This essentially allows one to do the deep learning -> symbolic regression technique from https://github.com/MilesCranmer/symbolic_deep_learning, but plug the discovered equation back into the network, without any manual work.

This is the same format as the JAX export - it expects a matrix `X` as input with columns corresponding to symbols, except it outputs a PyTorch module with embedded parameters instead of a (function, parameters) tuple.

@patrick-kidger, what do you think of this way of doing things? The modifications from your package include: expects matrix X as input rather than different vector for each symbol (to unify with the JAX backend) and only one expression per module (was unclear how to merge multiple expressions which the user may or may not use).