### PR TITLE
Revert unstable Symbolics update in backend

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,5 +2,5 @@
 SymbolicRegression = "8254be44-1295-4e6a-a16d-46603ac705cb"
 
 [compat]
-SymbolicRegression = "0.6.10, 0.6.11, 0.6.12"
+SymbolicRegression = "0.6.10"
 julia = "1.5"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pysr",
-    version="0.6.12-1",
+    version="0.6.13",
     author="Miles Cranmer",
     author_email="miles.cranmer@gmail.com",
     description="Simple and efficient symbolic regression",


### PR DESCRIPTION
The update applied to the backend updating SymbolicUtils.jl to 0.13 (used in 0.6.11 onwards) in https://github.com/MilesCranmer/SymbolicRegression.jl/pull/37 unfortunately introduced several (subtle, stochastic) issues, so I am reverting this change in PySR (won't affect the Julia standalone) until the refactored backend has stabilized. Two issues caused by the refactoring have been fixed, but I don't want other such issues to show up to new users.