### PR TITLE
Switch Julia interface to PyJulia

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,6 +61,7 @@ jobs:
             python -m pip install --upgrade pip
             pip install -r requirements.txt
             python setup.py install
+            python -c 'import julia; julia.install()'
       - name: "Install Coverage tool"
         run: pip install coverage coveralls
       - name: "Run tests"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,7 +61,7 @@ jobs:
             python -m pip install --upgrade pip
             pip install -r requirements.txt
             python setup.py install
-            python -c 'import julia; julia.install()'
+            python -c 'import pysr; pysr.install()'
       - name: "Install Coverage tool"
         run: pip install coverage coveralls
       - name: "Run tests"

--- a/.github/workflows/CI_Windows.yml
+++ b/.github/workflows/CI_Windows.yml
@@ -61,7 +61,7 @@ jobs:
             python -m pip install --upgrade pip
             pip install -r requirements.txt
             python setup.py install
-            python -c 'import julia; julia.install()'
+            python -c 'import pysr; pysr.install()'
       - name: "Run tests"
         run: python -m unittest test.test
         shell: bash

--- a/.github/workflows/CI_Windows.yml
+++ b/.github/workflows/CI_Windows.yml
@@ -61,6 +61,7 @@ jobs:
             python -m pip install --upgrade pip
             pip install -r requirements.txt
             python setup.py install
+            python -c 'import julia; julia.install()'
       - name: "Run tests"
         run: python -m unittest test.test
         shell: bash

--- a/.github/workflows/CI_conda.yml
+++ b/.github/workflows/CI_conda.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
             python -m pip install --upgrade pip
             conda install -c conda-forge $(cat requirements.txt | grep -v "julia" | xargs echo | sed "s/_/-/g")
-            pip install .
+            python setup.py install
             python -c 'import pysr; pysr.install()'
       - name: "Ensure that static libpython warning appears"
         run: python test/test_static_libpython_warning.py

--- a/.github/workflows/CI_conda.yml
+++ b/.github/workflows/CI_conda.yml
@@ -60,37 +60,17 @@ jobs:
           miniforge-variant: Mambaforge
           miniforge-version: latest
           auto-activate-base: true
-          channels: conda-forge
           python-version: ${{ matrix.python-version }}
           activate-environment: test
+          environment-file: environment.yml
       - name: "Install PySR"
         run: |
-            mamba install -c conda-forge pip $(cat requirements.txt | grep -v "julia" | xargs echo | sed "s/_/-/g")
-            python -m pip install julia
-            python setup.py install
-            python -c 'import pysr; pysr.install()'
-      - name: "Ensure that static libpython warning appears"
-        run: python test/test_static_libpython_warning.py
-      - name: "Install Coverage tool"
-        run: mamba install -c conda-forge coverage coveralls
-      - name: "Run tests"
-        run: coverage run --source=pysr --omit='*/feynman_problems.py' -m unittest test.test
+            python3 -m pip install .
+            python3 -c 'import pysr; pysr.install()'
         shell: bash
-      - name: Coveralls
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: ${{ matrix.test-name }}
-          COVERALLS_PARALLEL: true
-        run: coveralls --service=github
-  coveralls:
-    name: Indicate completion to coveralls.io
-    needs: test
-    runs-on: ubuntu-latest
-    container: python:3-slim
-    steps:
-      - name: Finished
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-            pip install coveralls
-            coveralls --finish
+      - name: "Ensure that static libpython warning appears"
+        run: python3 test/test_static_libpython_warning.py
+        shell: bash
+      - name: "Run tests"
+        run: python3 -m unittest discover -s test
+        shell: bash

--- a/.github/workflows/CI_conda.yml
+++ b/.github/workflows/CI_conda.yml
@@ -72,5 +72,5 @@ jobs:
         run: python3 test/test_static_libpython_warning.py
         shell: bash -l {0}
       - name: "Run tests"
-        run: python3 -m unittest discover -s test
+        run: python3 -m unittest test.test
         shell: bash -l {0}

--- a/.github/workflows/CI_conda.yml
+++ b/.github/workflows/CI_conda.yml
@@ -67,10 +67,10 @@ jobs:
         run: |
             python3 -m pip install .
             python3 -c 'import pysr; pysr.install()'
-        shell: bash
+        shell: bash -l {0}
       - name: "Ensure that static libpython warning appears"
         run: python3 test/test_static_libpython_warning.py
-        shell: bash
+        shell: bash -l {0}
       - name: "Run tests"
         run: python3 -m unittest discover -s test
-        shell: bash
+        shell: bash -l {0}

--- a/.github/workflows/CI_conda.yml
+++ b/.github/workflows/CI_conda.yml
@@ -67,6 +67,8 @@ jobs:
             conda install -c conda-forge $(cat requirements.txt | grep -v "julia" | xargs echo | sed "s/_/-/g")
             pip install .
             python -c 'import pysr; pysr.install()'
+      - name: "Ensure that static libpython warning appears"
+        run: python test/test_static_libpython_warning.py
       - name: "Install Coverage tool"
         run: pip install coverage coveralls
       - name: "Run tests"

--- a/.github/workflows/CI_conda.yml
+++ b/.github/workflows/CI_conda.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ['1.5.0', '1.6.1', '1.7.1']
-        python-version: ['3.7', '3.8', '3.9']
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        julia-version: ['1.7.1']
+        python-version: ['3.9']
+        os: ['ubuntu-latest']
     
     steps:
       - uses: actions/checkout@v1.0.0

--- a/.github/workflows/CI_conda.yml
+++ b/.github/workflows/CI_conda.yml
@@ -57,20 +57,22 @@ jobs:
       - name: "Set up Conda"
         uses: conda-incubator/setup-miniconda@v2
         with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
           auto-activate-base: true
-          auto-update-conda: true
           channels: conda-forge
           python-version: ${{ matrix.python-version }}
+          activate-environment: test
       - name: "Install PySR"
         run: |
-            python -m pip install --upgrade pip
-            conda install -c conda-forge $(cat requirements.txt | grep -v "julia" | xargs echo | sed "s/_/-/g")
+            mamba install -c conda-forge pip $(cat requirements.txt | grep -v "julia" | xargs echo | sed "s/_/-/g")
+            python -m pip install julia
             python setup.py install
             python -c 'import pysr; pysr.install()'
       - name: "Ensure that static libpython warning appears"
         run: python test/test_static_libpython_warning.py
       - name: "Install Coverage tool"
-        run: pip install coverage coveralls
+        run: mamba install -c conda-forge coverage coveralls
       - name: "Run tests"
         run: coverage run --source=pysr --omit='*/feynman_problems.py' -m unittest test.test
         shell: bash

--- a/.github/workflows/CI_conda.yml
+++ b/.github/workflows/CI_conda.yml
@@ -1,0 +1,92 @@
+name: CI_conda
+# This tests whether conda, a statically-linked libpython, works
+# with PySR.
+
+on:
+  push:
+    branches:
+      - '*'
+    paths:
+      - 'test/**'
+      - 'pysr/**'
+      - '.github/workflows/**'
+      - 'setup.py'
+      - 'Project.toml'
+  pull_request:
+    branches:
+      - '*'
+    paths:
+      - 'test/**'
+      - 'pysr/**'
+      - '.github/workflows/**'
+      - 'setup.py'
+      - 'Project.toml'
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: ['1.5.0', '1.6.1', '1.7.1']
+        python-version: ['3.7', '3.8', '3.9']
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+    
+    steps:
+      - uses: actions/checkout@v1.0.0
+      - name: "Set up Julia"
+        uses: julia-actions/setup-julia@v1.6.0
+        with:
+          version: ${{ matrix.julia-version }}
+      - name: "Change package server"
+        shell: bash
+        env:
+            JULIA_PKG_SERVER: ""
+        run: |
+            julia -e 'using Pkg; Pkg.Registry.add("General")'
+      - name: "Cache dependencies"
+        uses: actions/cache@v1 # Thanks FromFile.jl
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: "Set up Conda"
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-activate-base: true
+          auto-update-conda: true
+          channels: conda-forge
+          python-version: ${{ matrix.python-version }}
+      - name: "Install PySR"
+        run: |
+            python -m pip install --upgrade pip
+            conda install -c conda-forge $(cat requirements.txt | grep -v "julia" | xargs echo | sed "s/_/-/g")
+            pip install .
+            python -c 'import pysr; pysr.install()'
+      - name: "Install Coverage tool"
+        run: pip install coverage coveralls
+      - name: "Run tests"
+        run: coverage run --source=pysr --omit='*/feynman_problems.py' -m unittest test.test
+        shell: bash
+      - name: Coveralls
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_FLAG_NAME: ${{ matrix.test-name }}
+          COVERALLS_PARALLEL: true
+        run: coveralls --service=github
+  coveralls:
+    name: Indicate completion to coveralls.io
+    needs: test
+    runs-on: ubuntu-latest
+    container: python:3-slim
+    steps:
+      - name: Finished
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+            pip install coveralls
+            coveralls --finish

--- a/.github/workflows/CI_mac.yml
+++ b/.github/workflows/CI_mac.yml
@@ -61,7 +61,7 @@ jobs:
             python -m pip install --upgrade pip
             pip install -r requirements.txt
             python setup.py install
-            python -c 'import julia; julia.install()'
+            python -c 'import pysr; pysr.install()'
       - name: "Run tests"
         run: python -m unittest test.test
         shell: bash

--- a/.github/workflows/CI_mac.yml
+++ b/.github/workflows/CI_mac.yml
@@ -61,6 +61,7 @@ jobs:
             python -m pip install --upgrade pip
             pip install -r requirements.txt
             python setup.py install
+            python -c 'import julia; julia.install()'
       - name: "Run tests"
         run: python -m unittest test.test
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ dist
 pysr/.vs/
 pysr.egg-info
 Manifest.toml
+workflow

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ dist
 *.pyproj
 *.sln
 pysr/.vs/
+pysr.egg-info
+Manifest.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,44 @@
 # This builds a dockerfile containing a working copy of PySR
 # with all pre-requisites installed.
 
-
 ARG VERSION=latest
+
 FROM julia:$VERSION
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
-    build-essential python3 python3-dev python3-pip python3-setuptools \
-    vim git wget curl \
+    make build-essential libssl-dev zlib1g-dev \
+    libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
+    libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
+    vim git \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /pysr
+
+# Install PyEnv to switch Python to dynamically linked version:
+RUN curl https://pyenv.run | bash
+ENV PATH="/root/.pyenv/bin:$PATH"
+
+ENV PYTHON_VERSION="3.9.10"
+RUN PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install ${PYTHON_VERSION}
+ENV PATH="/root/.pyenv/versions/${PYTHON_VERSION}/bin:$PATH"
+
+# Install IPython and other useful libraries:
+RUN pip install ipython jupyter matplotlib
 
 # Caches install (https://stackoverflow.com/questions/25305788/how-to-avoid-reinstalling-packages-when-building-docker-image-for-python-project)
 ADD ./requirements.txt /pysr/requirements.txt
 RUN pip3 install -r /pysr/requirements.txt
 
 # Install PySR:
-ADD . /pysr/
+# We do a minimal copy so it doesn't need to rerun at every file change:
+ADD ./setup.py /pysr/setup.py
+ADD ./README.md /pysr/README.md
+Add ./Project.toml /pysr/Project.toml
+ADD ./pysr/ /pysr/pysr/
 RUN pip3 install .
 
 # Install Julia pre-requisites:
-RUN julia -e 'using Pkg; Pkg.add("SymbolicRegression")'
-
-# Install IPython and other useful libraries:
-RUN pip3 install ipython jupyter matplotlib
+RUN python3 -c 'import pysr; pysr.install()'
 
 CMD ["bash"]

--- a/Project.toml
+++ b/Project.toml
@@ -2,5 +2,5 @@
 SymbolicRegression = "8254be44-1295-4e6a-a16d-46603ac705cb"
 
 [compat]
-SymbolicRegression = "0.6.10"
+SymbolicRegression = "0.6.18"
 julia = "1.5"

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ You can install PySR with:
 pip3 install pysr
 python3 -c 'import pysr; pysr.install()'
 ```
-The second line will install the required Julia packages.
+The second line will install and update the required Julia packages, including
+`PyCall.jl`.
 
 
 Most common issues at this stage are solved

--- a/README.md
+++ b/README.md
@@ -62,11 +62,13 @@ and [linux](https://julialang.org/downloads/platform/#linux_and_freebsd).
 
 You can install PySR with:
 ```bash
-pip install pysr
+pip3 install pysr
+python3 -c 'import pysr; pysr.install()'
 ```
+The second line will install the required Julia packages.
 
-The first launch will automatically install the Julia packages
-required. Most common issues at this stage are solved
+
+Most common issues at this stage are solved
 by [tweaking the Julia package server](https://github.com/MilesCranmer/PySR/issues/27).
 to use up-to-date packages.
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ which gives:
 x0**2 + 2.000016*cos(x3) - 1.9999845
 ```
 
+The second and additional calls of `pysr` will be significantly
+faster in startup time, since the first call to Julia will compile
+and cache functions from the symbolic regression backend.
+
 One can also use `best_tex` to get the LaTeX form,
 or `best_callable` to get a function you can call.
 This uses a score which balances complexity and error;

--- a/docs/start.md
+++ b/docs/start.md
@@ -42,6 +42,10 @@ which gives:
 x0**2 + 2.000016*cos(x3) - 1.9999845
 ```
 
+The second and additional calls of `pysr` will be significantly
+faster in startup time, since the first call to Julia will compile
+and cache functions from the symbolic regression backend.
+
 One can also use `best_tex` to get the LaTeX form,
 or `best_callable` to get a function you can call.
 This uses a score which balances complexity and error;

--- a/docs/start.md
+++ b/docs/start.md
@@ -7,20 +7,14 @@ Install Julia - see [downloads](https://julialang.org/downloads/), and
 then instructions for [mac](https://julialang.org/downloads/platform/#macos)
 and [linux](https://julialang.org/downloads/platform/#linux_and_freebsd).
 (Don't use the `conda-forge` version; it doesn't seem to work properly.)
-Then, at the command line,
-install the `Optim` and `SpecialFunctions` packages via:
 
+You can install PySR with:
 ```bash
-julia -e 'import Pkg; Pkg.add("Optim"); Pkg.add("SpecialFunctions")'
+pip3 install pysr
+python3 -c 'import pysr; pysr.install()'
 ```
-
-For python, you need to have Python 3, numpy, sympy, and pandas installed.
-
-You can install this package from PyPI with:
-
-```bash
-pip install pysr
-```
+The second line will install and update the required Julia packages, including
+`PyCall.jl`.
 
 ## Quickstart
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,14 @@
+name: test
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.9
+  - sympy
+  - pandas
+  - numpy
+  - scikit-learn
+  - setuptools
+  - pip
+  - pip:
+    - julia

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.9
   - sympy
   - pandas
   - numpy

--- a/pysr/__init__.py
+++ b/pysr/__init__.py
@@ -1,4 +1,13 @@
-from .sr import pysr, get_hof, best, best_tex, best_callable, best_row, install
+from .sr import (
+    pysr,
+    get_hof,
+    best,
+    best_tex,
+    best_callable,
+    best_row,
+    install,
+    silence_julia_warning,
+)
 from .feynman_problems import Problem, FeynmanProblem
 from .export_jax import sympy2jax
 from .export_torch import sympy2torch

--- a/pysr/__init__.py
+++ b/pysr/__init__.py
@@ -1,4 +1,4 @@
-from .sr import pysr, get_hof, best, best_tex, best_callable, best_row
+from .sr import pysr, get_hof, best, best_tex, best_callable, best_row, install
 from .feynman_problems import Problem, FeynmanProblem
 from .export_jax import sympy2jax
 from .export_torch import sympy2torch

--- a/pysr/feynman_problems.py
+++ b/pysr/feynman_problems.py
@@ -80,20 +80,14 @@ def mk_problems(first=100, gen=False, dp=500, data_dir=FEYNMAN_DATASET):
     """
     ret = []
     with open(data_dir) as csvfile:
-        ind = 0
         reader = csv.DictReader(csvfile)
         for i, row in enumerate(reader):
-            if ind > first:
+            if i > first:
                 break
             if row["Filename"] == "":
                 continue
-            try:
-                p = FeynmanProblem(row, gen=gen, dp=dp)
-                ret.append(p)
-            except Exception as e:
-                traceback.print_exc()
-                print(f"FAILED ON ROW {i} with {e}")
-            ind += 1
+            p = FeynmanProblem(row, gen=gen, dp=dp)
+            ret.append(p)
     return ret
 
 

--- a/pysr/feynman_problems.py
+++ b/pysr/feynman_problems.py
@@ -1,6 +1,5 @@
 import numpy as np
 import csv
-import traceback
 from .sr import pysr, best
 from pathlib import Path
 from functools import partial

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1,12 +1,9 @@
 import os
 import sys
-from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
-from collections import namedtuple
-import pathlib
 import numpy as np
 import pandas as pd
 import sympy
-from sympy import sympify, Symbol, lambdify
+from sympy import sympify, lambdify
 import subprocess
 import tempfile
 import shutil

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -25,6 +25,7 @@ global_state = dict(
     multioutput=False,
     nout=1,
     selection=None,
+    raw_julia_output=None,
 )
 
 already_ran = False
@@ -499,7 +500,7 @@ def pysr(
 
     cprocs = 0 if multithreading else procs
 
-    output_equations = Main.EquationSearch(
+    raw_julia_output = Main.EquationSearch(
         Main.X,
         Main.y,
         weights=Main.weights,
@@ -522,6 +523,7 @@ def pysr(
         multioutput=multioutput,
         nout=nout,
         selection=selection,
+        raw_julia_output=raw_julia_output,
     )
 
     equations = get_hof(
@@ -541,7 +543,7 @@ def pysr(
     if delete_tempfiles:
         shutil.rmtree(tmpdir)
 
-    return equations, output_equations
+    return equations
 
 
 def _set_globals(
@@ -557,6 +559,7 @@ def _set_globals(
     multioutput,
     nout,
     selection,
+    raw_julia_output,
 ):
     global global_state
 
@@ -571,6 +574,7 @@ def _set_globals(
     global_state["multioutput"] = multioutput
     global_state["nout"] = nout
     global_state["selection"] = selection
+    global_state["raw_julia_output"] = raw_julia_output
 
 
 def _handle_constraints(binary_operators, unary_operators, constraints):

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -685,7 +685,7 @@ def run_feature_selection(X, y, select_k_features):
     features as output."""
 
     from sklearn.ensemble import RandomForestRegressor
-    from sklearn.feature_selection import SelectFromModel, SelectKBest
+    from sklearn.feature_selection import SelectFromModel
 
     clf = RandomForestRegressor(n_estimators=100, max_depth=3, random_state=0)
     clf.fit(X, y)

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -624,7 +624,7 @@ def _create_julia_files(
         else:
             julia_project = Path(julia_project)
 
-        if not already_ran_with_pyjulia:
+        if (pyjulia and not already_ran_with_pyjulia) or (not pyjulia):
             print(f"import Pkg", file=f)
             print(f'Pkg.activate("{_escape_filename(julia_project)}")', file=f)
             if need_install:

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -281,12 +281,13 @@ def pysr(
     # Start up Julia:
     global Main
     if pyjulia and Main is None:
-        if not multithreading:
-            raise AssertionError(
-                "PyJulia does not support multiprocessing. Turn multithreading=True."
-            )
+        # if not multithreading:
+        #     raise AssertionError(
+        #         "PyJulia does not support multiprocessing. Turn multithreading=True."
+        #     )
 
-        os.environ["JULIA_NUM_THREADS"] = str(procs)
+        if multithreading:
+            os.environ["JULIA_NUM_THREADS"] = str(procs)
         from julia import Main
 
     buffer_available = "buffer" in sys.stdout.__dir__() and not pyjulia
@@ -560,7 +561,7 @@ def pysr(
     else:
         kwargs["def_datasets"] = _make_datasets_julia_str(**kwargs)
 
-    _create_julia_files(**kwargs)
+        _create_julia_files(**kwargs)
         _final_pysr_process(**kwargs)
 
     _set_globals(**kwargs)
@@ -649,24 +650,24 @@ def _create_julia_files(
     with open(hyperparam_filename, "w") as f:
         print(def_hyperparams, file=f)
 
-        with open(dataset_filename, "w") as f:
-            print(def_datasets, file=f)
+    with open(dataset_filename, "w") as f:
+        print(def_datasets, file=f)
 
     with open(runfile_filename, "w") as f:
 
-            print(f"import Pkg", file=f)
-            print(f'Pkg.activate("{_escape_filename(julia_project)}")', file=f)
-            if need_install:
-                print(f"Pkg.instantiate()", file=f)
-                print("Pkg.update()", file=f)
-                print("Pkg.precompile()", file=f)
-            elif update:
-                print(f"Pkg.update()", file=f)
-            print(f"using SymbolicRegression", file=f)
+        print(f"import Pkg", file=f)
+        print(f'Pkg.activate("{_escape_filename(julia_project)}")', file=f)
+        if need_install:
+            print(f"Pkg.instantiate()", file=f)
+            print("Pkg.update()", file=f)
+            print("Pkg.precompile()", file=f)
+        elif update:
+            print(f"Pkg.update()", file=f)
+        print(f"using SymbolicRegression", file=f)
 
         print(f'include("{_escape_filename(hyperparam_filename)}")', file=f)
 
-            print(f'include("{_escape_filename(dataset_filename)}")', file=f)
+        print(f'include("{_escape_filename(dataset_filename)}")', file=f)
 
         varMap = _make_varmap(X, variable_names)
 

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -826,7 +826,9 @@ def get_hof(
                 cur_score = 0.0
             else:
                 if curMSE > 0.0:
-                    cur_score = -np.log(curMSE / lastMSE) / (curComplexity - lastComplexity)
+                    cur_score = -np.log(curMSE / lastMSE) / (
+                        curComplexity - lastComplexity
+                    )
                 else:
                     cur_score = np.inf
 

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -518,10 +518,8 @@ def pysr(
     global already_ran_with_pyjulia
     if pyjulia:
         # Read entire file as a single string:
-        with open(kwargs["runfile_filename"], "r") as f:
-            runfile_string = f.read()
         print("Running main runfile in PyJulia!")
-        Main.eval(runfile_string)
+        Main.eval(f"include('{_escape_filename(kwargs['runfile_filename'])}')")
         already_ran_with_pyjulia = True
     else:
         _final_pysr_process(**kwargs)

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -149,6 +149,7 @@ def pysr(
     Xresampled=None,
     precision=32,
     multithreading=None,
+    **kwargs,
 ):
     """Run symbolic regression to fit f(X[i, :]) ~ y[i] for all i.
     Note: most default parameters have been tuned over several example
@@ -265,6 +266,8 @@ def pysr(
     :type precision: int
     :param multithreading: Use multithreading instead of distributed backend. Default is yes. Using procs=0 will turn off both.
     :type multithreading: bool
+    :param **kwargs: Other options passed to SymbolicRegression.Options, for example, if you modify SymbolicRegression.jl to include additional arguments.
+    :type **kwargs: dict
     :returns: Results dataframe, giving complexity, MSE, and equations (as strings), as well as functional forms. If list, each element corresponds to a dataframe of equations for each output.
     :type: pd.DataFrame/list
     """
@@ -507,6 +510,7 @@ Tried to activate project {julia_project} but failed."""
         verbosity=int(verbosity),
         progress=progress,
         terminal_width=int(term_width),
+        **kwargs,
     )
 
     np_dtype = {16: np.float16, 32: np.float32, 64: np.float64}[precision]

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -396,16 +396,6 @@ def pysr(
         manifest_filepath = Path(julia_project) / "Manifest.toml"
         julia_project = Path(julia_project)
 
-    need_install = False
-
-    if not (manifest_filepath).is_file() and not pyjulia:
-        need_install = (not user_input) or _yesno(
-            "I will install Julia packages using PySR's Project.toml file. OK?"
-        )
-        if need_install:
-            print("OK. I will install at launch.")
-            assert update
-
     _create_inline_operators(
         binary_operators=binary_operators, unary_operators=unary_operators
     )
@@ -427,12 +417,10 @@ def pysr(
         from julia import Pkg
 
         Pkg.activate(f"{_escape_filename(julia_project)}")
-        if need_install:
+        if update is not False:
             Pkg.instantiate()
             Pkg.update()
             Pkg.precompile()
-        elif update:
-            Pkg.update()
 
         Main.eval("using SymbolicRegression")
 

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -135,7 +135,6 @@ def pysr(
     tempdir=None,
     delete_tempfiles=True,
     julia_project=None,
-    user_input=True,
     update=True,
     temp_equation_file=False,
     output_jax_format=False,
@@ -248,8 +247,6 @@ def pysr(
     :type delete_tempfiles: bool
     :param julia_project: a Julia environment location containing a Project.toml (and potentially the source code for SymbolicRegression.jl).  Default gives the Python package directory, where a Project.toml file should be present from the install.
     :type julia_project: str/None
-    :param user_input: Whether to ask for user input or not for installing (to be used for automated scripts). Will choose to install when asked.
-    :type user_input: bool
     :param update: Whether to automatically update Julia packages.
     :type update: bool
     :param temp_equation_file: Whether to put the hall of fame file in the temp directory. Deletion is then controlled with the delete_tempfiles argument.
@@ -439,18 +436,19 @@ Required dependencies are not installed or built.  Run the following code in the
         from julia import Pkg
 
         Pkg.activate(f"{_escape_filename(julia_project)}")
-        try:
-            Pkg.resolve()
-        except RuntimeError as e:
-            raise ImportError(
-                f"""
+        if update:
+            try:
+                Pkg.resolve()
+            except RuntimeError as e:
+                raise ImportError(
+                    f"""
 Required dependencies are not installed or built.  Run the following code in the Python REPL:
 
     >>> import pysr
     >>> pysr.install()
-    
+        
 Tried to activate project {julia_project} but failed."""
-            ) from e
+                ) from e
         Main.eval("using SymbolicRegression")
 
         Main.plus = Main.eval("(+)")
@@ -629,7 +627,6 @@ def _handle_constraints(binary_operators, unary_operators, constraints):
 
 
 def _create_inline_operators(binary_operators, unary_operators):
-    global Main
     for op_list in [binary_operators, unary_operators]:
         for i, op in enumerate(op_list):
             is_user_defined_operator = "(" in op

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -423,23 +423,24 @@ def pysr(
     except:
         _, term_width = subprocess.check_output(["stty", "size"]).split()
 
-    from julia import Pkg
+    if not already_ran:
+        from julia import Pkg
 
-    Pkg.activate(f"{_escape_filename(julia_project)}")
-    if need_install:
-        Pkg.instantiate()
-        Pkg.update()
-        Pkg.precompile()
-    elif update:
-        Pkg.update()
+        Pkg.activate(f"{_escape_filename(julia_project)}")
+        if need_install:
+            Pkg.instantiate()
+            Pkg.update()
+            Pkg.precompile()
+        elif update:
+            Pkg.update()
 
-    Main.eval("using SymbolicRegression")
+        Main.eval("using SymbolicRegression")
 
-    Main.plus = Main.eval("(+)")
-    Main.sub = Main.eval("(-)")
-    Main.mult = Main.eval("(*)")
-    Main.pow = Main.eval("(^)")
-    Main.div = Main.eval("(/)")
+        Main.plus = Main.eval("(+)")
+        Main.sub = Main.eval("(-)")
+        Main.mult = Main.eval("(*)")
+        Main.pow = Main.eval("(^)")
+        Main.div = Main.eval("(/)")
 
     Main.custom_loss = Main.eval(loss)
 

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -23,8 +23,8 @@ def install(julia_project=None):
     from julia import Pkg
 
     Pkg.activate(f"{_escape_filename(julia_project)}")
-    Pkg.instantiate()
     Pkg.update()
+    Pkg.instantiate()
     Pkg.precompile()
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ sympy
 pandas
 numpy
 scikit_learn
+julia

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/MilesCranmer/pysr",
-    install_requires=["numpy", "pandas", "sympy"],
+    install_requires=["julia", "numpy", "pandas", "sympy"],
     packages=setuptools.find_packages(),
     package_data={"pysr": ["../Project.toml", "../datasets/*"]},
     include_package_data=False,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pysr",
-    version="0.6.14",
+    version="0.7.0",
     author="Miles Cranmer",
     author_email="miles.cranmer@gmail.com",
     description="Simple and efficient symbolic regression",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pysr",
-    version="0.7.0",
+    version="0.7.0rc1",
     author="Miles Cranmer",
     author_email="miles.cranmer@gmail.com",
     description="Simple and efficient symbolic regression",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pysr",
-    version="0.7.0rc1",
+    version="0.7.0a1",
     author="Miles Cranmer",
     author_email="miles.cranmer@gmail.com",
     description="Simple and efficient symbolic regression",

--- a/test/test.py
+++ b/test/test.py
@@ -13,7 +13,6 @@ class TestPipeline(unittest.TestCase):
         self.default_test_kwargs = dict(
             niterations=10,
             populations=4,
-            user_input=False,
             annealing=True,
             useFrequency=False,
         )

--- a/test/test_static_libpython_warning.py
+++ b/test/test_static_libpython_warning.py
@@ -3,6 +3,7 @@
 import warnings
 import pysr
 
+# Taken from https://stackoverflow.com/a/14463362/2689923
 with warnings.catch_warnings(record=True) as warning_catcher:
     warnings.simplefilter("always")
     pysr.sr.init_julia()

--- a/test/test_static_libpython_warning.py
+++ b/test/test_static_libpython_warning.py
@@ -1,0 +1,12 @@
+"""Test that running PySR with static libpython raises a warning."""
+
+import warnings
+import pysr
+
+with warnings.catch_warnings(record=True) as warning_catcher:
+    warnings.simplefilter("always")
+    pysr.sr.init_julia()
+
+    assert len(warning_catcher) == 1
+    assert issubclass(warning_catcher[-1].category, UserWarning)
+    assert "static" in str(warning_catcher[-1].message)


### PR DESCRIPTION
This switches the entirety of the Julia/Python interface to use PyJulia rather than a `subprocess` call to a generated script. Multithreading and distributed computing both work! 

This brings several advantages:

- Huge speedups in startup time on second `pysr( )` calls in the same python call
- Simplified error debugging on the Julia side
- Greatly simplified codebase with no huge chunks of code generation
- Possibility to checkpoint the symbolic regression search, and restart later

The disadvantage is that this will put PySR at the mercy of PyJulia and any bugs that it experiences. However, I think in the longterm this is still much better than running a script of generating code.

Installation with this new interface is now:
```bash
pip install pysr
python -c 'import pysr; pysr.install()'
```
This will install PyCall.jl (required by PyJulia) as well as the packages defined in `SymbolicRegression.jl`.

Will initially be implemented in v0.7.0a1 for a while until things stabilize.


TODO:

- [x] Update documentation to describe PyJulia install.
- [x] Update documentation to mention that repeat calls will have a quicker startup time.
- [x] Check that error is correct when PyJulia not installed if `pysr.install()` has not been run.
- [x] Check if there are any performance hits using PyJulia vs Julia.
- [x] Make it so we can KeyboardInterrupt the PyJulia execution of EquationSearch. See https://github.com/JuliaPy/pyjulia/issues/211.
- [x] This does not work when python is statically linked. In this situation, should we use `compiled_modules=False`? Or enfoce that the user has to get this working?
- [x] Is there anything I can do to get conda working with PyCall.jl?
- [x] Test conda with the CI.