### PR TITLE
Reverts to SymbolicUtils.jl v0.6 to temporarily fix the simplification backend

### DIFF
--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1044,7 +1044,7 @@ def _write_project_file(tmp_dir):
 SymbolicRegression = "8254be44-1295-4e6a-a16d-46603ac705cb"
 
 [compat]
-SymbolicRegression = "0.6.19"
+SymbolicRegression = "0.7.0"
 julia = "1.5"
     """
 

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -445,19 +445,22 @@ def pysr(
         from julia import Pkg
 
         Pkg.activate(f"{_escape_filename(julia_project)}")
-        if update:
-            try:
+        try:
+            if update:
                 Pkg.resolve()
-            except RuntimeError as e:
-                raise ImportError(
-                    f"""
+                Pkg.instantiate()
+            else:
+                Pkg.instantiate()
+        except RuntimeError as e:
+            raise ImportError(
+                f"""
 Required dependencies are not installed or built.  Run the following code in the Python REPL:
 
     >>> import pysr
     >>> pysr.install()
-        
+    
 Tried to activate project {julia_project} but failed."""
-                ) from e
+            ) from e
         Main.eval("using SymbolicRegression")
 
         Main.plus = Main.eval("(+)")

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -121,7 +121,7 @@ def pysr(
     weightMutateConstant=10,
     weightMutateOperator=1,
     weightRandomize=1,
-    weightSimplify=0.01,
+    weightSimplify=0.002,
     perturbationFactor=1.0,
     extra_sympy_mappings=None,
     extra_torch_mappings=None,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pysr",
-    version="0.7.0a2",
+    version="0.7.0a3",
     author="Miles Cranmer",
     author_email="miles.cranmer@gmail.com",
     description="Simple and efficient symbolic regression",


### PR DESCRIPTION
See https://github.com/MilesCranmer/SymbolicRegression.jl/issues/59 for a discussion.

This also:
- lowers the default simplification frequency by 5x which seems to speed up the searches a bit.
- Runs `Pkg.instantiate()` regardless of whether `update=True` or `False`. This will enforce that the correct version of SymbolicRegression.jl is used.