### PR TITLE
Add mechanism to manually do model selection

### DIFF
--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -274,7 +274,9 @@ class CallableEquation:
         expected_shape = (X.shape[0],)
         if isinstance(X, pd.DataFrame):
             # Lambda function takes as argument:
-            return self._lambda(**{k: X[k].values for k in X.columns}) * np.ones(expected_shape)
+            return self._lambda(**{k: X[k].values for k in X.columns}) * np.ones(
+                expected_shape
+            )
         elif self._selection is not None:
             return self._lambda(*X[:, self._selection].T) * np.ones(expected_shape)
         return self._lambda(*X.T) * np.ones(expected_shape)

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -779,21 +779,21 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
             **{key: self.__getattribute__(key) for key in self.surface_parameters},
         }
 
-    def get_best(self, row=None):
+    def get_best(self, index=None):
         """Get best equation using `model_selection`.
 
-        :param row: Optional. If you wish to select a particular equation
+        :param index: Optional. If you wish to select a particular equation
             from `self.equations`, give the row number here. This overrides
             the `model_selection` parameter.
-        :type row: int
+        :type index: int
         :returns: Dictionary representing the best expression found.
         :type: pd.Series
         """
         if self.equations is None:
             raise ValueError("No equations have been generated yet.")
 
-        if row is not None:
-            return self.equations.iloc[row]
+        if index is not None:
+            return self.equations.iloc[index]
 
         if self.model_selection == "accuracy":
             if isinstance(self.equations, list):
@@ -838,7 +838,7 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
         # such as extra_sympy_mappings.
         self.equations = self.get_hof()
 
-    def predict(self, X, row=None):
+    def predict(self, X, index=None):
         """Predict y from input X using the equation chosen by `model_selection`.
 
         You may see what equation is used by printing this object. X should have the same
@@ -846,60 +846,60 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
 
         :param X: 2D array. Rows are examples, columns are features. If pandas DataFrame, the columns are used for variable names (so make sure they don't contain spaces).
         :type X: np.ndarray/pandas.DataFrame
-        :param row: Optional. If you want to predict an expression using a particular row of
-            `self.equations`, you may specify the row here.
-        :type row: int
+        :param index: Optional. If you want to predict an expression using a particular row of
+            `self.equations`, you may specify the index here.
+        :type index: int
         :returns: 1D array (rows are examples) or 2D array (rows are examples, columns are outputs).
         :type: np.ndarray
         """
         self.refresh()
-        best = self.get_best(row=row)
+        best = self.get_best(index=index)
         if self.multioutput:
             return np.stack([eq["lambda_format"](X) for eq in best], axis=1)
         return best["lambda_format"](X)
 
-    def sympy(self, row=None):
+    def sympy(self, index=None):
         """Return sympy representation of the equation(s) chosen by `model_selection`.
 
-        :param row: Optional. If you wish to select a particular equation
-            from `self.equations`, give the row number here. This overrides
+        :param index: Optional. If you wish to select a particular equation
+            from `self.equations`, give the index number here. This overrides
             the `model_selection` parameter.
-        :type row: int
+        :type index: int
         :returns: SymPy representation of the best expression.
         """
         self.refresh()
-        best = self.get_best(row=row)
+        best = self.get_best(index=index)
         if self.multioutput:
             return [eq["sympy_format"] for eq in best]
         return best["sympy_format"]
 
-    def latex(self, row=None):
+    def latex(self, index=None):
         """Return latex representation of the equation(s) chosen by `model_selection`.
 
-        :param row: Optional. If you wish to select a particular equation
-            from `self.equations`, give the row number here. This overrides
+        :param index: Optional. If you wish to select a particular equation
+            from `self.equations`, give the index number here. This overrides
             the `model_selection` parameter.
-        :type row: int
+        :type index: int
         :returns: LaTeX expression as a string
         :type: str
         """
         self.refresh()
-        sympy_representation = self.sympy(row=row)
+        sympy_representation = self.sympy(index=index)
         if self.multioutput:
             return [sympy.latex(s) for s in sympy_representation]
         return sympy.latex(sympy_representation)
 
-    def jax(self, row=None):
+    def jax(self, index=None):
         """Return jax representation of the equation(s) chosen by `model_selection`.
 
         Each equation (multiple given if there are multiple outputs) is a dictionary
         containing {"callable": func, "parameters": params}. To call `func`, pass
         func(X, params). This function is differentiable using `jax.grad`.
 
-        :param row: Optional. If you wish to select a particular equation
-            from `self.equations`, give the row number here. This overrides
+        :param index: Optional. If you wish to select a particular equation
+            from `self.equations`, give the index number here. This overrides
             the `model_selection` parameter.
-        :type row: int
+        :type index: int
         :returns: Dictionary of callable jax function in "callable" key,
             and jax array of parameters as "parameters" key.
         :type: dict
@@ -912,12 +912,12 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
             )
         self.set_params(output_jax_format=True)
         self.refresh()
-        best = self.get_best(row=row)
+        best = self.get_best(index=index)
         if self.multioutput:
             return [eq["jax_format"] for eq in best]
         return best["jax_format"]
 
-    def pytorch(self, row=None):
+    def pytorch(self, index=None):
         """Return pytorch representation of the equation(s) chosen by `model_selection`.
 
         Each equation (multiple given if there are multiple outputs) is a PyTorch module
@@ -926,10 +926,10 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
         column ordering as trained with.
 
 
-        :param row: Optional. If you wish to select a particular equation
+        :param index: Optional. If you wish to select a particular equation
             from `self.equations`, give the row number here. This overrides
             the `model_selection` parameter.
-        :type row: int
+        :type index: int
         :returns: PyTorch module representing the expression.
         :type: torch.nn.Module
         """
@@ -941,7 +941,7 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
             )
         self.set_params(output_torch_format=True)
         self.refresh()
-        best = self.get_best(row=row)
+        best = self.get_best(index=index)
         if self.multioutput:
             return [eq["torch_format"] for eq in best]
         return best["torch_format"]

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -781,7 +781,7 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
 
     def get_best(self, row=None):
         """Get best equation using `model_selection`.
-        
+
         :param row: Optional. If you wish to select a particular equation
             from `self.equations`, give the row number here. This overrides
             the `model_selection` parameter.
@@ -860,7 +860,7 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
 
     def sympy(self, row=None):
         """Return sympy representation of the equation(s) chosen by `model_selection`.
-        
+
         :param row: Optional. If you wish to select a particular equation
             from `self.equations`, give the row number here. This overrides
             the `model_selection` parameter.
@@ -875,7 +875,7 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
 
     def latex(self, row=None):
         """Return latex representation of the equation(s) chosen by `model_selection`.
-        
+
         :param row: Optional. If you wish to select a particular equation
             from `self.equations`, give the row number here. This overrides
             the `model_selection` parameter.
@@ -925,7 +925,7 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
         any other PyTorch module: `module(X)`, where `X` is a tensor with the same
         column ordering as trained with.
 
-        
+
         :param row: Optional. If you wish to select a particular equation
             from `self.equations`, give the row number here. This overrides
             the `model_selection` parameter.

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -271,12 +271,13 @@ class CallableEquation:
         return f"PySRFunction(X=>{self._sympy})"
 
     def __call__(self, X):
+        expected_shape = (X.shape[0],)
         if isinstance(X, pd.DataFrame):
             # Lambda function takes as argument:
-            return self._lambda(**{k: X[k].values for k in X.columns})
+            return self._lambda(**{k: X[k].values for k in X.columns}) * np.ones(expected_shape)
         elif self._selection is not None:
-            return self._lambda(*X[:, self._selection].T)
-        return self._lambda(*X.T)
+            return self._lambda(*X[:, self._selection].T) * np.ones(expected_shape)
+        return self._lambda(*X.T) * np.ones(expected_shape)
 
 
 def _get_julia_project(julia_project):

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -793,6 +793,9 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
             raise ValueError("No equations have been generated yet.")
 
         if index is not None:
+            if isinstance(self.equations, list):
+                assert isinstance(index, list)
+                return [self.equations.iloc[i] for i in index]
             return self.equations.iloc[index]
 
         if self.model_selection == "accuracy":
@@ -846,7 +849,8 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
 
         :param X: 2D array. Rows are examples, columns are features. If pandas DataFrame, the columns are used for variable names (so make sure they don't contain spaces).
         :type X: np.ndarray/pandas.DataFrame
-        :param index: Optional. If you want to predict an expression using a particular row of
+        :param index: Optional. If you want to compute the output of
+            an expression using a particular row of
             `self.equations`, you may specify the index here.
         :type index: int
         :returns: 1D array (rows are examples) or 2D array (rows are examples, columns are outputs).

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -795,7 +795,7 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
         if index is not None:
             if isinstance(self.equations, list):
                 assert isinstance(index, list)
-                return [self.equations.iloc[i] for i in index]
+                return [eq.iloc[i] for eq, i in zip(self.equations, index)]
             return self.equations.iloc[index]
 
         if self.model_selection == "accuracy":

--- a/test/test.py
+++ b/test/test.py
@@ -212,7 +212,7 @@ class TestBest(unittest.TestCase):
 
     def test_best(self):
         self.assertEqual(self.model.sympy(), sympy.cos(sympy.Symbol("x0")) ** 2)
-    
+
     def test_index_selection(self):
         self.assertEqual(self.model.sympy(-1), sympy.cos(sympy.Symbol("x0")) ** 2)
         self.assertEqual(self.model.sympy(2), sympy.cos(sympy.Symbol("x0")) ** 2)

--- a/test/test.py
+++ b/test/test.py
@@ -203,6 +203,12 @@ class TestBest(unittest.TestCase):
 
     def test_best(self):
         self.assertEqual(self.model.sympy(), sympy.cos(sympy.Symbol("x0")) ** 2)
+    
+    def test_index_selection(self):
+        self.assertEqual(self.model.sympy(-1), sympy.cos(sympy.Symbol("x0")) ** 2)
+        self.assertEqual(self.model.sympy(2), sympy.cos(sympy.Symbol("x0")) ** 2)
+        self.assertEqual(self.model.sympy(1), sympy.cos(sympy.Symbol("x0")))
+        self.assertEqual(self.model.sympy(0), 1.0)
 
     def test_best_tex(self):
         self.assertEqual(self.model.latex(), "\\cos^{2}{\\left(x_{0} \\right)}")

--- a/test/test.py
+++ b/test/test.py
@@ -61,6 +61,10 @@ class TestPipeline(unittest.TestCase):
         self.assertLessEqual(mse1, 1e-4)
         self.assertLessEqual(mse2, 1e-4)
 
+        bad_y = model.predict(self.X, index=[0, 0])
+        bad_mse = np.average((bad_y - y) ** 2)
+        self.assertGreater(bad_mse, 1e-4)
+
     def test_multioutput_weighted_with_callable_temp_equation(self):
         y = self.X[:, [0, 1]] ** 2
         w = np.random.rand(*y.shape)

--- a/test/test.py
+++ b/test/test.py
@@ -52,6 +52,15 @@ class TestPipeline(unittest.TestCase):
         self.assertLessEqual(equations[0].iloc[-1]["loss"], 1e-4)
         self.assertLessEqual(equations[1].iloc[-1]["loss"], 1e-4)
 
+        test_y1 = model.predict(self.X)
+        test_y2 = model.predict(self.X, index=[-1, -1])
+
+        mse1 = np.average((test_y1 - y) ** 2)
+        mse2 = np.average((test_y2 - y) ** 2)
+
+        self.assertLessEqual(mse1, 1e-4)
+        self.assertLessEqual(mse2, 1e-4)
+
     def test_multioutput_weighted_with_callable_temp_equation(self):
         y = self.X[:, [0, 1]] ** 2
         w = np.random.rand(*y.shape)


### PR DESCRIPTION
By passing, for example, `model.predict(X, index=2)`, you will perform a prediction using the 2nd equation in the internal `model.equations` dataframe. You can view the index of each expression by running `print(model)`, or simply looking at `model.equations`.

This allows the user to specify their own model selection strategy, and is quite a simple change to the codebase. It also works for the sympy, latex, pytorch, and jax export functions–simply by changing the argument of `.get_best` to have a row kwarg.