### PR TITLE
Add mappings from sympy exact One/Half

### DIFF
--- a/pysr/export_jax.py
+++ b/pysr/export_jax.py
@@ -48,6 +48,9 @@ _jnp_func_lookup = {
     sympy.Max: "jnp.max",
     sympy.Min: "jnp.min",
     sympy.Mod: "jnp.mod",
+    sympy.Heaviside: "jnp.heaviside",
+    sympy.core.numbers.Half: "(lambda: 0.5)",
+    sympy.core.numbers.One: "(lambda: 1.0)",
 }
 
 

--- a/pysr/export_torch.py
+++ b/pysr/export_torch.py
@@ -77,6 +77,9 @@ def _initialize_torch():
             sympy.Max: torch.max,
             sympy.Min: torch.min,
             sympy.Mod: torch.remainder,
+            sympy.Heaviside: torch.heaviside,
+            sympy.core.numbers.Half: (lambda: 0.5),
+            sympy.core.numbers.One: (lambda: 1.0),
         }
 
         class _Node(torch.nn.Module):


### PR DESCRIPTION
Sometimes SymPy will create weird functions when evaluating a string (even without running `.simplify()`, such as `sympy.core.numbers.One` (for exact 1) and `sympy.core.numbers.Half` (exact 1/2).

This adds those functions to the JAX and PyTorch. This also adds the heaviside function, which is useful when searching the space of branched functions (like an if statement). 