### PR TITLE
Enable custom cluster managers

### DIFF
--- a/pysr/version.py
+++ b/pysr/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 __symbolic_regression_jl_version__ = "0.8.7"


### PR DESCRIPTION
This let's PySR launch jobs over a cluster. If you are on a slurm cluster (on the head node of a job), you simply pass `cluster_manager="slurm"` to PySRRegressor, and it will set up a bunch of workers over the slurm job. Likewise, the other cluster managers listed on https://github.com/JuliaParallel/ClusterManagers.jl can be used.

The one unfortunate thing is I don't think this functionality can be unit-tested; it will just be manual tests on clusters.

cc @KazeWong!