### PR TITLE
New exit strategies: max_evals and early_stop_condition

### DIFF
--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -420,6 +420,7 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
         cluster_manager=None,
         skip_mutation_failures=True,
         max_evals=None,
+        early_stop_condition=None,
         # To support deprecated kwargs:
         **kwargs,
     ):
@@ -562,6 +563,8 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
         :type skip_mutation_failures: bool
         :param max_evals: Limits the total number of evaluations of expressions to this number.
         :type max_evals: int
+        :param early_stop_condition: Stop the search early if this loss is reached.
+        :type early_stop_condition: float
         :param kwargs: Supports deprecated keyword arguments. Other arguments will result
         in an error
         :type kwargs: dict
@@ -749,6 +752,7 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
                 cluster_manager=cluster_manager,
                 skip_mutation_failures=skip_mutation_failures,
                 max_evals=max_evals,
+                early_stop_condition=early_stop_condition,
             ),
         }
 
@@ -1313,8 +1317,9 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
             progress=self.params["progress"],
             timeout_in_seconds=self.params["timeout_in_seconds"],
             crossoverProbability=self.params["crossover_probability"],
-            max_evals=self.params["max_evals"],
             skip_mutation_failures=self.params["skip_mutation_failures"],
+            max_evals=self.params["max_evals"],
+            earlyStopCondition=self.params["early_stop_condition"],
         )
 
         np_dtype = {16: np.float16, 32: np.float32, 64: np.float64}[

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -419,6 +419,7 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
         multithreading=None,
         cluster_manager=None,
         skip_mutation_failures=True,
+        max_evals=None,
         # To support deprecated kwargs:
         **kwargs,
     ):
@@ -559,6 +560,8 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
         :type precision: int
         :param skip_mutation_failures: Whether to skip mutation and crossover failures, rather than simply re-sampling the current member.
         :type skip_mutation_failures: bool
+        :param max_evals: Limits the total number of evaluations of expressions to this number.
+        :type max_evals: int
         :param kwargs: Supports deprecated keyword arguments. Other arguments will result
         in an error
         :type kwargs: dict
@@ -745,6 +748,7 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
                 multithreading=multithreading,
                 cluster_manager=cluster_manager,
                 skip_mutation_failures=skip_mutation_failures,
+                max_evals=max_evals,
             ),
         }
 
@@ -1309,6 +1313,7 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
             progress=self.params["progress"],
             timeout_in_seconds=self.params["timeout_in_seconds"],
             crossoverProbability=self.params["crossover_probability"],
+            max_evals=self.params["max_evals"],
             skip_mutation_failures=self.params["skip_mutation_failures"],
         )
 

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -418,7 +418,6 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
         precision=32,
         multithreading=None,
         cluster_manager=None,
-        use_symbolic_utils=False,
         skip_mutation_failures=True,
         # To support deprecated kwargs:
         **kwargs,
@@ -558,8 +557,6 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
         :type tournament_selection_p: float
         :param precision: What precision to use for the data. By default this is 32 (float32), but you can select 64 or 16 as well.
         :type precision: int
-        :param use_symbolic_utils: Whether to use SymbolicUtils during simplification.
-        :type use_symbolic_utils: bool
         :param skip_mutation_failures: Whether to skip mutation and crossover failures, rather than simply re-sampling the current member.
         :type skip_mutation_failures: bool
         :param kwargs: Supports deprecated keyword arguments. Other arguments will result
@@ -747,7 +744,6 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
                 precision=precision,
                 multithreading=multithreading,
                 cluster_manager=cluster_manager,
-                use_symbolic_utils=use_symbolic_utils,
                 skip_mutation_failures=skip_mutation_failures,
             ),
         }
@@ -1310,7 +1306,6 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
             perturbationFactor=self.params["perturbation_factor"],
             annealing=self.params["annealing"],
             stateReturn=True,  # Required for state saving.
-            use_symbolic_utils=self.params["use_symbolic_utils"],
             progress=self.params["progress"],
             timeout_in_seconds=self.params["timeout_in_seconds"],
             crossoverProbability=self.params["crossover_probability"],

--- a/pysr/version.py
+++ b/pysr/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.8.1"
-__symbolic_regression_jl_version__ = "0.8.7"
+__version__ = "0.8.2"
+__symbolic_regression_jl_version__ = "0.9.1"


### PR DESCRIPTION
There are now several stop conditions for a PySR search.
1. `niterations` - PySR will exit after the set number of iterations have passed.
2. `timeout_in_seconds` - exit based on clock time.
3. `max_evals` - exit after a certain number of evaluations have occurred. (**NEW**)
4. `early_stop_condition` - exit after a certain loss has been met. (**NEW**)
5. Manually hitting `q` or `<ctl-c>` and then enter during the search, if you are using it interactively.