### PR TITLE
Allow custom complexities for operators, constants, and variables

### DIFF
--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1263,7 +1263,7 @@ class PySRRegressor(BaseEstimator, RegressorMixin):
                 complexity_of_operators_str += f"({k}) => {v}, "
             complexity_of_operators_str += ")"
             complexity_of_operators = Main.eval(complexity_of_operators_str)
-        
+
         Main.custom_loss = Main.eval(loss)
 
         mutationWeights = [

--- a/pysr/version.py
+++ b/pysr/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.8.4"
-__symbolic_regression_jl_version__ = "0.9.1"
+__version__ = "0.8.5"
+__symbolic_regression_jl_version__ = "0.9.2"

--- a/test/test.py
+++ b/test/test.py
@@ -41,11 +41,12 @@ class TestPipeline(unittest.TestCase):
         print(model.equations)
         self.assertLessEqual(model.equations.iloc[-1]["loss"], 1e-4)
 
-    def test_multioutput_custom_operator_quiet(self):
+    def test_multioutput_custom_operator_quiet_custom_complexity(self):
         y = self.X[:, [0, 1]] ** 2
         model = PySRRegressor(
             unary_operators=["square_op(x) = x^2"],
             extra_sympy_mappings={"square_op": lambda x: x**2},
+            complexity_of_operators={"square_op": 2, "plus": 1},
             binary_operators=["plus"],
             verbosity=0,
             **self.default_test_kwargs,


### PR DESCRIPTION
This adds the options introduced in https://github.com/MilesCranmer/SymbolicRegression.jl/pull/105.

For example:
```python
model = PySRRegressor(
    ...
    complexity_of_operators={"sin": 3, "exp": 5, "+": 1},  # Default is 1 per operator
    complexity_of_constants=2,  # Default 1
    complexity_of_variables=3,  # Default 1
)
```
would make an expression like:

```
sin(x1 + 3.2 * exp(2.1))
```
have a complexity of 3+3+1+2+1+5+2 = 17, rather than simply 1+1+1+1+1+1+1 = 7.

(Also works for custom operators)