### PR TITLE
Refactor of PySRRegressor

### DIFF
--- a/pysr/export_jax.py
+++ b/pysr/export_jax.py
@@ -109,7 +109,7 @@ def _initialize_jax():
         jsp = _jsp
 
 
-def sympy2jax(expression, symbols_in, extra_jax_mappings=None):
+def sympy2jax(expression, symbols_in, selection=None, extra_jax_mappings=None):
     """Returns a function f and its parameters;
     the function takes an input matrix, and a list of arguments:
             f(X, parameters)
@@ -192,6 +192,9 @@ def sympy2jax(expression, symbols_in, extra_jax_mappings=None):
     )
     hash_string = "A_" + str(abs(hash(str(expression) + str(symbols_in))))
     text = f"def {hash_string}(X, parameters):\n"
+    if selection is not None:
+        # Impose the feature selection:
+        text += f"    X = X[:, {list(selection)}]\n"
     text += "    return "
     text += functional_form_text
     ldict = {}

--- a/pysr/export_numpy.py
+++ b/pysr/export_numpy.py
@@ -13,7 +13,6 @@ class CallableEquation:
         self._sympy_symbols = sympy_symbols
         self._selection = selection
         self._variable_names = variable_names
-        self._lambda = lambdify(sympy_symbols, eqn)
 
     def __repr__(self):
         return f"PySRFunction(X=>{self._sympy})"
@@ -35,3 +34,7 @@ class CallableEquation:
                 )
                 X = X[:, self._selection]
         return self._lambda(*X.T) * np.ones(expected_shape)
+
+    @property
+    def _lambda(self):
+        return lambdify(self._sympy_symbols, self._sympy)

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -976,6 +976,13 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                     "`multithreading` to `False` or `None`, and `procs` to `0`."
                 )
 
+        if self.random_state != None and (not self.deterministic or self.procs != 0):
+            warnings.warn(
+                "Note: Setting `random_state` without also setting `deterministic` "
+                "to True and `procs` to 0 "
+                "will result in non-deterministic searches. "
+            )
+
         # NotImplementedError - Values that could be supported at a later time
         if self.optimizer_algorithm not in VALID_OPTIMIZER_ALGORITHMS:
             raise NotImplementedError(

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1749,7 +1749,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         extra_jax_mappings = self.extra_jax_mappings
         extra_torch_mappings = self.extra_torch_mappings
         if extra_jax_mappings is not None:
-            for value in self.extra_jax_mappings.values():
+            for value in extra_jax_mappings.values():
                 if not isinstance(value, str):
                     raise ValueError(
                         "extra_jax_mappings must have keys that are strings! e.g., {sympy.sqrt: 'jnp.sqrt'}."
@@ -1757,7 +1757,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         else:
             extra_jax_mappings = {}
         if extra_torch_mappings is not None:
-            for value in self.extra_jax_mappings.values():
+            for value in extra_jax_mappings.values():
                 if not callable(value):
                     raise ValueError(
                         "extra_torch_mappings must be callable functions! e.g., {sympy.sqrt: torch.sqrt}."

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1307,7 +1307,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             complexity_of_operators_str += ")"
             complexity_of_operators = Main.eval(complexity_of_operators_str)
 
-        Main.custom_loss = Main.eval(self.loss)
+        custom_loss = Main.eval(self.loss)
 
         mutationWeights = [
             float(self.weight_mutate_constant),
@@ -1331,7 +1331,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             complexity_of_constants=self.complexity_of_constants,
             complexity_of_variables=self.complexity_of_variables,
             nested_constraints=nested_constraints,
-            loss=Main.custom_loss,
+            loss=custom_loss,
             maxsize=int(self.maxsize),
             hofFile=_escape_filename(self.equation_file_),
             npopulations=int(self.populations),

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1740,6 +1740,7 @@ class PySRRegressor(BaseEstimator, RegressorMixin, MultiOutputMixin):
                     func, params = sympy2jax(
                         eqn,
                         sympy_symbols,
+                        selection=self.selection_mask_,
                         extra_jax_mappings=self.extra_jax_mappings,
                     )
                     jax_format.append({"callable": func, "parameters": params})

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -220,12 +220,11 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         this number.
 
     maxsize : int, default=20
-        Max size of an equation.
+        Max complexity of an equation.
 
     maxdepth : int, default=None
         Max depth of an equation. You can use both :param`maxsize` and
-        :param`maxdepth`. :param`maxdepth` is by default set to equal
-        :param`maxsize`, which means that it is redundant.
+        :param`maxdepth`. :param`maxdepth` is by default not used.
 
     warmup_maxsize_by : float, default=0.0
         Whether to slowly increase max size from a small number up to
@@ -240,8 +239,8 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         Dictionary of int (unary) or 2-tuples (binary), this enforces
         maxsize constraints on the individual arguments of operators.
         E.g., `'pow': (-1, 1)` says that power laws can have any
-        complexity left argument, but only 1 complexity exponent. Use
-        this to force more interpretable solutions.
+        complexity left argument, but only 1 complexity in the right
+        argument. Use this to force more interpretable solutions.
 
     nested_constraints : dict[str, dict], default=None
         Specifies how many times a combination of operators can be
@@ -683,31 +682,30 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         self.unary_operators = unary_operators
         self.niterations = niterations
         self.populations = populations
-        # - Model search Constraints
         self.population_size = population_size
-        self.max_evals = max_evals
+        self.ncyclesperiteration = ncyclesperiteration
+        # - Equation Constraints
         self.maxsize = maxsize
         self.maxdepth = maxdepth
-        self.warmup_maxsize_by = warmup_maxsize_by
-        self.timeout_in_seconds = timeout_in_seconds
         self.constraints = constraints
         self.nested_constraints = nested_constraints
+        self.warmup_maxsize_by = warmup_maxsize_by
+        # - Early exit conditions:
+        self.max_evals = max_evals
+        self.timeout_in_seconds = timeout_in_seconds
+        self.early_stop_condition = early_stop_condition
         # - Loss parameters
         self.loss = loss
         self.complexity_of_operators = complexity_of_operators
         self.complexity_of_constants = complexity_of_constants
         self.complexity_of_variables = complexity_of_variables
-        self.parsimony = float(parsimony)
+        self.parsimony = parsimony
         self.use_frequency = use_frequency
         self.use_frequency_in_tournament = use_frequency_in_tournament
         self.alpha = alpha
         self.annealing = annealing
-        self.early_stop_condition = early_stop_condition
         # - Evolutionary search parameters
         # -- Mutation parameters
-        self.ncyclesperiteration = ncyclesperiteration
-        self.fraction_replaced = fraction_replaced
-        self.fraction_replaced_hof = fraction_replaced_hof
         self.weight_add_node = weight_add_node
         self.weight_insert_node = weight_insert_node
         self.weight_delete_node = weight_delete_node
@@ -721,6 +719,8 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         # -- Migration parameters
         self.migration = migration
         self.hof_migration = hof_migration
+        self.fraction_replaced = fraction_replaced
+        self.fraction_replaced_hof = fraction_replaced_hof
         self.topn = topn
         # -- Constants parameters
         self.should_optimize_constants = should_optimize_constants

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -965,6 +965,17 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         elif self.maxsize < 7:
             raise ValueError("PySR requires a maxsize of at least 7")
 
+        if self.deterministic:
+            if not (
+                self.multithreading in [False, None]
+                and self.procs == 0
+                and self.random_state != None
+            ):
+                raise ValueError(
+                    "To ensure deterministic searches, you must set `random_state` to a seed, "
+                    "`multithreading` to `False` or `None`, and `procs` to `0`."
+                )
+
         # NotImplementedError - Values that could be supported at a later time
         if self.optimizer_algorithm not in VALID_OPTIMIZER_ALGORITHMS:
             raise NotImplementedError(

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -894,6 +894,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         NotImplementedError
             Raised when an invalid model selection strategy is provided.
         """
+        check_is_fitted(self, attributes=["equations_"])
         if self.equations_ is None:
             raise ValueError("No equations have been generated yet.")
 
@@ -1544,7 +1545,9 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         ValueError
             Raises if the `best_equation` cannot be evaluated.
         """
-        self.refresh()
+        check_is_fitted(
+            self, attributes=["selection_mask_", "feature_names_in_", "nout_"]
+        )
         best_equation = self.get_best(index=index)
 
         # When X is an numpy array or a pandas dataframe with a RangeIndex,

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -922,17 +922,6 @@ class PySRRegressor(BaseEstimator, RegressorMixin, MultiOutputMixin):
             )
             self.batch_size = 1
 
-        if n_samples > 10000 and not self.batching:
-            warnings.warn(
-                "Note: you are running with more than 10,000 datapoints. "
-                "You should consider turning on batching (https://astroautomata.com/PySR/#/options?id=batching). "
-                "You should also reconsider if you need that many datapoints. "
-                "Unless you have a large amount of noise (in which case you "
-                "should smooth your dataset first), generally < 10,000 datapoints "
-                "is enough to find a functional form with symbolic regression. "
-                "More datapoints will lower the search speed."
-            )
-
         # Ensure instance parameters are allowable values:
         # ValueError - Incompatible values
         if self.tournament_selection_n > self.population_size:
@@ -1020,6 +1009,17 @@ class PySRRegressor(BaseEstimator, RegressorMixin, MultiOutputMixin):
             Validated list of variable names for each feature in `X`.
 
         """
+        if X.shape[1] > 10000 and not self.batching:
+            warnings.warn(
+                "Note: you are running with more than 10,000 datapoints. "
+                "You should consider turning on batching (https://astroautomata.com/PySR/#/options?id=batching). "
+                "You should also reconsider if you need that many datapoints. "
+                "Unless you have a large amount of noise (in which case you "
+                "should smooth your dataset first), generally < 10,000 datapoints "
+                "is enough to find a functional form with symbolic regression. "
+                "More datapoints will lower the search speed."
+            )
+
         if isinstance(X, pd.DataFrame):
             if variable_names:
                 variable_names = None

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1312,7 +1312,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             complexity_of_operators = Main.eval(complexity_of_operators_str)
 
         custom_loss = Main.eval(self.loss)
-        early_stop_condition = Main.eval(self.early_stop_condition)
+        early_stop_condition = Main.eval(str(self.early_stop_condition))
 
         mutationWeights = [
             float(self.weight_mutate_constant),

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -2,7 +2,7 @@ import os
 import sys
 import numpy as np
 import pandas as pd
-from sklearn.utils import check_array, check_random_state
+from sklearn.utils import check_array, check_consistent_length, check_random_state
 import sympy
 from sympy import sympify
 import re
@@ -15,7 +15,7 @@ from multiprocessing import cpu_count
 from sklearn.base import BaseEstimator, RegressorMixin, MultiOutputMixin
 from sklearn.utils.validation import (
     _check_feature_names_in,
-    _check_sample_weight,
+    check_X_y,
     check_is_fitted,
 )
 
@@ -1073,7 +1073,8 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         if Xresampled is not None:
             Xresampled = check_array(Xresampled)
         if weights is not None:
-            weights = _check_sample_weight(weights, y)
+            weights = check_array(weights)
+            check_consistent_length(weights, y)
         X, y = self._validate_data(X=X, y=y, reset=True, multi_output=True)
         self.feature_names_in_ = _check_feature_names_in(self, variable_names)
         variable_names = self.feature_names_in_
@@ -1461,7 +1462,6 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
 
         mutated_params = self._validate_init_params()
 
-        # Parameter input validation (for parameters defined in __init__)
         X, y, Xresampled, weights, variable_names = self._validate_fit_params(
             X, y, Xresampled, weights, variable_names
         )

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -435,6 +435,12 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         Pass an int for reproducible results across multiple function calls.
         See :term:`Glossary <random_state>`.
 
+    deterministic : bool, default=False
+        Make a PySR search give the same result every run.
+        To use this, you must turn off parallelism
+        (with :param`procs`=0, :param`multithreading`=False),
+        and set :param`random_state` to a fixed seed.
+
     warm_start : bool, default=False
         Tells fit to continue from where the last call to fit finished.
         If false, each call to fit will be fresh, overwriting previous results.
@@ -647,6 +653,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         fast_cycle=False,
         precision=32,
         random_state=None,
+        deterministic=False,
         warm_start=False,
         verbosity=1e9,
         update_verbosity=None,
@@ -732,6 +739,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         self.fast_cycle = fast_cycle
         self.precision = precision
         self.random_state = random_state
+        self.deterministic = deterministic
         self.warm_start = warm_start
         # Additional runtime parameters
         # - Runtime user interface
@@ -1363,6 +1371,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             max_evals=self.max_evals,
             earlyStopCondition=self.early_stop_condition,
             seed=seed,
+            deterministic=self.deterministic,
         )
 
         # Convert data to desired precision

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -2,7 +2,6 @@ import os
 import sys
 import numpy as np
 import pandas as pd
-from sklearn.utils import check_array, check_consistent_length, check_random_state
 import sympy
 from sympy import sympify
 import re
@@ -13,6 +12,7 @@ from datetime import datetime
 import warnings
 from multiprocessing import cpu_count
 from sklearn.base import BaseEstimator, RegressorMixin, MultiOutputMixin
+from sklearn.utils import check_array, check_consistent_length, check_random_state
 from sklearn.utils.validation import (
     _check_feature_names_in,
     check_is_fitted,
@@ -76,7 +76,8 @@ sympy_mappings = {
 
 def pysr(X, y, weights=None, **kwargs):  # pragma: no cover
     warnings.warn(
-        "Calling `pysr` is deprecated. Please use `model = PySRRegressor(**params); model.fit(X, y)` going forward.",
+        "Calling `pysr` is deprecated. "
+        "Please use `model = PySRRegressor(**params); model.fit(X, y)` going forward.",
         FutureWarning,
     )
     model = PySRRegressor(**kwargs)
@@ -95,7 +96,8 @@ def _process_constraints(binary_operators, unary_operators, constraints):
         if op in ["plus", "sub", "+", "-"]:
             if constraints[op][0] != constraints[op][1]:
                 raise NotImplementedError(
-                    "You need equal constraints on both sides for - and +, due to simplification strategies."
+                    "You need equal constraints on both sides for - and +, "
+                    "due to simplification strategies."
                 )
         elif op in ["mult", "*"]:
             # Make sure the complex expression is in the left side.
@@ -128,7 +130,8 @@ def _maybe_create_inline_operators(binary_operators, unary_operators):
                 if not re.match(r"^[a-zA-Z0-9_]+$", function_name):
                     raise ValueError(
                         f"Invalid function name {function_name}. "
-                        "Only alphanumeric characters, numbers, and underscores are allowed."
+                        "Only alphanumeric characters, numbers, "
+                        "and underscores are allowed."
                     )
                 op_list[i] = function_name
     return binary_operators, unary_operators
@@ -154,25 +157,32 @@ def _check_assertions(
 
 def best(*args, **kwargs):  # pragma: no cover
     raise NotImplementedError(
-        "`best` has been deprecated. Please use the `PySRRegressor` interface. After fitting, you can return `.sympy()` to get the sympy representation of the best equation."
+        "`best` has been deprecated. Please use the `PySRRegressor` interface. "
+        "After fitting, you can return `.sympy()` to get the sympy representation "
+        "of the best equation."
     )
 
 
 def best_row(*args, **kwargs):  # pragma: no cover
     raise NotImplementedError(
-        "`best_row` has been deprecated. Please use the `PySRRegressor` interface. After fitting, you can run `print(model)` to view the best equation, or `model.get_best()` to return the best equation's row in `model.equations`."
+        "`best_row` has been deprecated. Please use the `PySRRegressor` interface. "
+        "After fitting, you can run `print(model)` to view the best equation, or "
+        "`model.get_best()` to return the best equation's row in `model.equations`."
     )
 
 
 def best_tex(*args, **kwargs):  # pragma: no cover
     raise NotImplementedError(
-        "`best_tex` has been deprecated. Please use the `PySRRegressor` interface. After fitting, you can return `.latex()` to get the sympy representation of the best equation."
+        "`best_tex` has been deprecated. Please use the `PySRRegressor` interface. "
+        "After fitting, you can return `.latex()` to get the sympy representation "
+        "of the best equation."
     )
 
 
 def best_callable(*args, **kwargs):  # pragma: no cover
     raise NotImplementedError(
-        "`best_callable` has been deprecated. Please use the `PySRRegressor` interface. After fitting, you can use `.predict(X)` to use the best callable."
+        "`best_callable` has been deprecated. Please use the `PySRRegressor` "
+        "interface. After fitting, you can use `.predict(X)` to use the best callable."
     )
 
 
@@ -775,7 +785,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                     setattr(self, updated_kwarg_name, v)
                     warnings.warn(
                         f"{k} has been renamed to {updated_kwarg_name} in PySRRegressor. "
-                        " Please use that instead.",
+                        "Please use that instead.",
                         FutureWarning,
                     )
                 # Handle kwargs that have been moved to the fit method
@@ -787,7 +797,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                     )
                 else:
                     raise TypeError(
-                        f"{k} is not a valid keyword argument for PySRRegressor"
+                        f"{k} is not a valid keyword argument for PySRRegressor."
                     )
 
     def __repr__(self):
@@ -964,7 +974,6 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             values. For example, default parameters are set here
             when a parameter is left set to `None`.
         """
-
         # Immutable parameter validation
         # Ensure instance parameters are allowable values:
         if self.tournament_selection_n > self.population_size:
@@ -974,27 +983,29 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
 
         if self.maxsize > 40:
             warnings.warn(
-                "Note: Using a large maxsize for the equation search will be exponentially slower and use significant memory. You should consider turning `use_frequency` to False, and perhaps use `warmup_maxsize_by`."
+                "Note: Using a large maxsize for the equation search will be "
+                "exponentially slower and use significant memory. You should consider "
+                "turning `use_frequency` to False, and perhaps use `warmup_maxsize_by`."
             )
         elif self.maxsize < 7:
             raise ValueError("PySR requires a maxsize of at least 7")
 
-        if self.deterministic:
-            if not (
-                self.multithreading in [False, None]
-                and self.procs == 0
-                and self.random_state != None
-            ):
-                raise ValueError(
-                    "To ensure deterministic searches, you must set `random_state` to a seed, "
-                    "`procs` to `0`, and `multithreading` to `False` or `None`."
-                )
+        if self.deterministic and not (
+            self.multithreading in [False, None]
+            and self.procs == 0
+            and self.random_state is not None
+        ):
+            raise ValueError(
+                "To ensure deterministic searches, you must set `random_state` to a seed, "
+                "`procs` to `0`, and `multithreading` to `False` or `None`."
+            )
 
-        if self.random_state != None and (not self.deterministic or self.procs != 0):
+        if self.random_state is not None and (
+            not self.deterministic or self.procs != 0
+        ):
             warnings.warn(
                 "Note: Setting `random_state` without also setting `deterministic` "
-                "to True and `procs` to 0 "
-                "will result in non-deterministic searches. "
+                "to True and `procs` to 0 will result in non-deterministic searches. "
             )
 
         # NotImplementedError - Values that could be supported at a later time
@@ -1035,7 +1046,8 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                     parameter_value = 1
                 elif parameter == "progress" and not buffer_available:
                     warnings.warn(
-                        "Note: it looks like you are running in Jupyter. The progress bar will be turned off."
+                        "Note: it looks like you are running in Jupyter. "
+                        "The progress bar will be turned off."
                     )
                     parameter_value = False
             packed_modified_params[parameter] = parameter_value
@@ -1087,7 +1099,6 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             Validated list of variable names for each feature in `X`.
 
         """
-
         if isinstance(X, pd.DataFrame):
             if variable_names:
                 variable_names = None
@@ -1803,7 +1814,8 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                 )
         except FileNotFoundError:
             raise RuntimeError(
-                "Couldn't find equation file! The equation search likely exited before a single iteration completed."
+                "Couldn't find equation file! The equation search likely exited "
+                "before a single iteration completed."
             )
 
         # It is expected extra_jax/torch_mappings will be updated after fit.
@@ -1814,7 +1826,8 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             for value in extra_jax_mappings.values():
                 if not isinstance(value, str):
                     raise ValueError(
-                        "extra_jax_mappings must have keys that are strings! e.g., {sympy.sqrt: 'jnp.sqrt'}."
+                        "extra_jax_mappings must have keys that are strings! "
+                        "e.g., {sympy.sqrt: 'jnp.sqrt'}."
                     )
         else:
             extra_jax_mappings = {}
@@ -1822,7 +1835,8 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             for value in extra_jax_mappings.values():
                 if not callable(value):
                     raise ValueError(
-                        "extra_torch_mappings must be callable functions! e.g., {sympy.sqrt: torch.sqrt}."
+                        "extra_torch_mappings must be callable functions! "
+                        "e.g., {sympy.sqrt: torch.sqrt}."
                     )
         else:
             extra_torch_mappings = {}

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1061,7 +1061,8 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
 
         # Data validation and feature name fetching via sklearn
         # This method sets the n_features_in_ attribute
-        Xresampled = check_array(Xresampled)
+        if Xresampled is not None:
+            Xresampled = check_array(Xresampled)
         X, y = self._validate_data(X=X, y=y, reset=True, multi_output=True)
         self.feature_names_in_ = _check_feature_names_in(self, variable_names)
         variable_names = self.feature_names_in_

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1405,7 +1405,7 @@ class PySRRegressor(BaseEstimator, RegressorMixin, MultiOutputMixin):
 
         self._setup_equation_file()
 
-        if X.shape[1] > 10000 and not self.batching:
+        if X.shape[0] > 10000 and not self.batching:
             warnings.warn(
                 "Note: you are running with more than 10,000 datapoints. "
                 "You should consider turning on batching (https://astroautomata.com/PySR/#/options?id=batching). "

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1015,16 +1015,6 @@ class PySRRegressor(BaseEstimator, RegressorMixin, MultiOutputMixin):
             Validated list of variable names for each feature in `X`.
 
         """
-        if X.shape[1] > 10000 and not self.batching:
-            warnings.warn(
-                "Note: you are running with more than 10,000 datapoints. "
-                "You should consider turning on batching (https://astroautomata.com/PySR/#/options?id=batching). "
-                "You should also reconsider if you need that many datapoints. "
-                "Unless you have a large amount of noise (in which case you "
-                "should smooth your dataset first), generally < 10,000 datapoints "
-                "is enough to find a functional form with symbolic regression. "
-                "More datapoints will lower the search speed."
-            )
 
         if isinstance(X, pd.DataFrame):
             if variable_names:
@@ -1414,6 +1404,17 @@ class PySRRegressor(BaseEstimator, RegressorMixin, MultiOutputMixin):
         self.raw_julia_state_ = None
 
         self._setup_equation_file()
+
+        if X.shape[1] > 10000 and not self.batching:
+            warnings.warn(
+                "Note: you are running with more than 10,000 datapoints. "
+                "You should consider turning on batching (https://astroautomata.com/PySR/#/options?id=batching). "
+                "You should also reconsider if you need that many datapoints. "
+                "Unless you have a large amount of noise (in which case you "
+                "should smooth your dataset first), generally < 10,000 datapoints "
+                "is enough to find a functional form with symbolic regression. "
+                "More datapoints will lower the search speed."
+            )
 
         # Parameter input validation (for parameters defined in __init__)
         X, y, Xresampled, variable_names = self._validate_fit_params(

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1752,6 +1752,7 @@ class PySRRegressor(BaseEstimator, RegressorMixin, MultiOutputMixin):
                     module = sympy2torch(
                         eqn,
                         sympy_symbols,
+                        selection=self.selection_mask_,
                         extra_torch_mappings=self.extra_torch_mappings,
                     )
                     torch_format.append(module)

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1311,7 +1311,9 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             complexity_of_operators = Main.eval(complexity_of_operators_str)
 
         custom_loss = Main.eval(self.loss)
-        early_stop_condition = Main.eval(str(self.early_stop_condition))
+        early_stop_condition = Main.eval(
+            str(self.early_stop_condition) if self.early_stop_condition else None
+        )
 
         mutation_weights = np.array(
             [

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1402,7 +1402,6 @@ class PySRRegressor(BaseEstimator, RegressorMixin, MultiOutputMixin):
         Xresampled=None,
         weights=None,
         variable_names=None,
-        from_equation_file=False,
     ):
         """
         Search for equations to fit the dataset and store them in `self.equations_`.
@@ -1500,18 +1499,21 @@ class PySRRegressor(BaseEstimator, RegressorMixin, MultiOutputMixin):
         )
 
         # Fitting procedure
-        if not from_equation_file:
-            self._run(X=X, y=y, weights=weights, seed=seed)
-        else:
-            self.equations_ = self.get_hof()
+        return self._run(X=X, y=y, weights=weights, seed=seed)
 
-        return self
-
-    def refresh(self):
+    def refresh(self, checkpoint_file=None):
         """
         Updates self.equations_ with any new options passed, such as
         :param`extra_sympy_mappings`.
+
+        Parameters
+        ----------
+        checkpoint_file : str, default=None
+            Path to checkpoint hall of fame file to be loaded.
         """
+        check_is_fitted(self, attributes=["equation_file_"])
+        if checkpoint_file:
+            self.equation_file_ = checkpoint_file
         self.equations_ = self.get_hof()
 
     def _decision_function(self, X, best_equation):
@@ -1709,6 +1711,15 @@ class PySRRegressor(BaseEstimator, RegressorMixin, MultiOutputMixin):
     def get_hof(self):
         """Get the equations from a hall of fame file. If no arguments
         entered, the ones used previously from a call to PySR will be used."""
+        check_is_fitted(
+            self,
+            attributes=[
+                "nout_",
+                "equation_file_",
+                "selection_mask_",
+                "feature_names_in_",
+            ],
+        )
         try:
             if self.nout_ > 1:
                 all_outputs = []

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1427,12 +1427,6 @@ class PySRRegressor(BaseEstimator, RegressorMixin, MultiOutputMixin):
             If :param`X` is a pandas dataframe, the column names will be used.
             If variable_names are specified
 
-        from_equation_file : bool, default=False
-            Allows model to be initialized/fit from a previous run that has
-            been saved to a file. If true, a value of y still needs to be
-            passed such that `nout_` can be determined, however, the values of
-            y are irrelevant and can be all zeros.
-
         Returns
         -------
         self : object

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -754,6 +754,8 @@ class PySRRegressor(BaseEstimator, RegressorMixin, MultiOutputMixin):
                         f"{k} is not a valid keyword argument for PySRRegressor"
                     )
 
+        self._process_params()
+
     def __repr__(self):
         """
         Prints all current equations fitted by the model.
@@ -858,20 +860,12 @@ class PySRRegressor(BaseEstimator, RegressorMixin, MultiOutputMixin):
                 f"{self.model_selection} is not a valid model selection strategy."
             )
 
-    def _validate_params(self, n_samples):
+    def _process_params(self):
         """
         Perform validation on the parameters defined in init for the
-        dataset specified in :term`fit`.
-
-        Parameters
-        ----------
-        n_samples : int
-            Number of samples in the dataset to be fitted.
-
-        Returns
-        -------
-        self : object
-            Reference to `self` with validated parameters.
+        dataset specified in :term`fit`, and update them if necessary.
+        For example, this will change :param`binary_operators`
+        into `["+", "-", "*", "/"]` if `binary_operators` is `None`.
 
         Raises
         ------
@@ -1406,7 +1400,6 @@ class PySRRegressor(BaseEstimator, RegressorMixin, MultiOutputMixin):
         self.raw_julia_state_ = None
 
         # Parameter input validation (for parameters defined in __init__)
-        self._validate_params(n_samples=X.shape[0])
         X, y, Xresampled, variable_names = self._validate_fit_params(
             X, y, Xresampled, variable_names
         )

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -950,7 +950,20 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         else:
             self.equation_file_ = self.equation_file
 
-    def _validate_init_params(self):
+    def _validate_and_set_init_params(self):
+        """
+        Ensures parameters passed at initialization are valid.
+
+        Also returns a dictionary of parameters to update from their
+        values given at initialization.
+
+        Returns
+        -------
+        packed_modified_params : dict
+            Dictionary of parameters to modify from their initialized
+            values. For example, default parameters are set here
+            when a parameter is left set to `None`.
+        """
 
         # Immutable parameter validation
         # Ensure instance parameters are allowable values:
@@ -1034,7 +1047,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         )
         return packed_modified_params
 
-    def _validate_fit_params(self, X, y, Xresampled, weights, variable_names):
+    def _validate_and_set_fit_params(self, X, y, Xresampled, weights, variable_names):
         """
         Validates the parameters passed to the :term`fit` method.
 
@@ -1504,9 +1517,9 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
 
         self._setup_equation_file()
 
-        mutated_params = self._validate_init_params()
+        mutated_params = self._validate_and_set_init_params()
 
-        X, y, Xresampled, weights, variable_names = self._validate_fit_params(
+        X, y, Xresampled, weights, variable_names = self._validate_and_set_fit_params(
             X, y, Xresampled, weights, variable_names
         )
 

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -857,12 +857,13 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         to be serialized. Note: Jax and Torch format equations are also removed
         from the pickled instance.
         """
-        warnings.warn(
-            "raw_julia_state_ cannot be pickled and will be removed from the "
-            "serialized instance. This will prevent a `warm_start` fit of any "
-            "model that is deserialized via `pickle.loads()`."
-        )
         state = self.__dict__
+        if "raw_julia_state_" in state:
+            warnings.warn(
+                "raw_julia_state_ cannot be pickled and will be removed from the "
+                "serialized instance. This will prevent a `warm_start` fit of any "
+                "model that is deserialized via `pickle.load()`."
+            )
         pickled_state = {
             key: None if key == "raw_julia_state_" else value
             for key, value in state.items()

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -132,15 +132,12 @@ def _maybe_create_inline_operators(binary_operators, unary_operators):
 
 def _check_assertions(
     X,
-    binary_operators,
-    unary_operators,
     use_custom_variable_names,
     variable_names,
     weights,
     y,
 ):
     # Check for potential errors before they happen
-    assert len(unary_operators) + len(binary_operators) > 0
     assert len(X.shape) == 2
     assert len(y.shape) in [1, 2]
     assert X.shape[0] == y.shape[0]
@@ -1125,6 +1122,8 @@ class PySRRegressor(BaseEstimator, RegressorMixin, MultiOutputMixin):
         elif isinstance(unary_operators, str):
             unary_operators = [unary_operators]
 
+        assert len(unary_operators) + len(binary_operators) > 0
+
         if constraints is None:
             constraints = {}
 
@@ -1436,8 +1435,6 @@ class PySRRegressor(BaseEstimator, RegressorMixin, MultiOutputMixin):
 
         _check_assertions(
             X,
-            self.binary_operators,
-            self.unary_operators,
             use_custom_variable_names,
             variable_names,
             weights,

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -15,7 +15,6 @@ from multiprocessing import cpu_count
 from sklearn.base import BaseEstimator, RegressorMixin, MultiOutputMixin
 from sklearn.utils.validation import (
     _check_feature_names_in,
-    check_X_y,
     check_is_fitted,
 )
 

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1314,16 +1314,19 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         custom_loss = Main.eval(self.loss)
         early_stop_condition = Main.eval(str(self.early_stop_condition))
 
-        mutationWeights = [
-            float(self.weight_mutate_constant),
-            float(self.weight_mutate_operator),
-            float(self.weight_add_node),
-            float(self.weight_insert_node),
-            float(self.weight_delete_node),
-            float(self.weight_simplify),
-            float(self.weight_randomize),
-            float(self.weight_do_nothing),
-        ]
+        mutation_weights = np.array(
+            [
+                self.weight_mutate_constant,
+                self.weight_mutate_operator,
+                self.weight_add_node,
+                self.weight_insert_node,
+                self.weight_delete_node,
+                self.weight_simplify,
+                self.weight_randomize,
+                self.weight_do_nothing,
+            ],
+            dtype=float,
+        )
 
         # Call to Julia backend.
         # See https://github.com/MilesCranmer/SymbolicRegression.jl/blob/master/src/OptionsStruct.jl
@@ -1342,7 +1345,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             npopulations=int(self.populations),
             batching=self.batching,
             batchSize=int(min([batch_size, len(X)]) if self.batching else len(X)),
-            mutationWeights=mutationWeights,
+            mutationWeights=mutation_weights,
             probPickFirst=self.tournament_selection_p,
             ns=self.tournament_selection_n,
             # These have the same name:

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -458,7 +458,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
     equation_file : str, default=None
         Where to save the files (.csv separated by |).
 
-    temp_equation_file :
+    temp_equation_file : bool, default=False
         Whether to put the hall of fame file in the temp directory.
         Deletion is then controlled with the :param`delete_tempfiles`
         parameter.

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -312,8 +312,11 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
     annealing : bool, default=True
         Whether to use annealing. You should (and it is default).
 
-    early_stop_condition : float, default=None
-        Stop the search early if this loss is reached.
+    early_stop_condition : { float | str }, default=None
+        Stop the search early if this loss is reached. You may also
+        pass a string containing a Julia function which
+        takes a loss and complexity as input, for example:
+        `"f(loss, complexity) = (loss < 0.1) && (complexity < 10)"`.
 
     ncyclesperiteration : int, default=550
         Number of total mutations to run, per 10 samples of the
@@ -971,6 +974,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
 
         # 'Mutable' parameter validation
         buffer_available = "buffer" in sys.stdout.__dir__()
+        # Params and their default values, if None is given:
         modifiable_params = {
             "binary_operators": "+ * - /".split(" "),
             "unary_operators": [],
@@ -1308,6 +1312,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             complexity_of_operators = Main.eval(complexity_of_operators_str)
 
         custom_loss = Main.eval(self.loss)
+        early_stop_condition = Main.eval(self.early_stop_condition)
 
         mutationWeights = [
             float(self.weight_mutate_constant),
@@ -1369,7 +1374,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             crossoverProbability=self.crossover_probability,
             skip_mutation_failures=self.skip_mutation_failures,
             max_evals=self.max_evals,
-            earlyStopCondition=self.early_stop_condition,
+            earlyStopCondition=early_stop_condition,
             seed=seed,
             deterministic=self.deterministic,
         )

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1464,6 +1464,13 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         if self.warm_start and hasattr(self, "raw_julia_state_"):
             pass
         else:
+            if hasattr(self, "raw_julia_state_"):
+                warnings.warn(
+                    "The discovered expressions are being reset. "
+                    "Please set `warm_start=True` if you wish to continue "
+                    "to start a search where you left off.",
+                )
+
             self.equations_ = None
             self.nout_ = 1
             self.selection_mask_ = None

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -565,7 +565,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
     >>> from pysr import PySRRegressor
     >>> randstate = np.random.RandomState(0)
     >>> X = 2 * randstate.randn(100, 5)
-    >>> # y = 2.5372 * cos(x_3) + x_0 - 0.5
+    >>> # y = 2.5382 * cos(x_3) + x_0 - 0.5
     >>> y = 2.5382 * np.cos(X[:, 3]) + X[:, 0] ** 2 - 0.5
     >>> model = PySRRegressor(
     ...     niterations=40,

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1392,6 +1392,11 @@ class PySRRegressor(BaseEstimator, RegressorMixin, MultiOutputMixin):
 
         self._setup_equation_file()
 
+        # Parameter input validation (for parameters defined in __init__)
+        X, y, Xresampled, variable_names = self._validate_fit_params(
+            X, y, Xresampled, variable_names
+        )
+
         if X.shape[0] > 10000 and not self.batching:
             warnings.warn(
                 "Note: you are running with more than 10,000 datapoints. "
@@ -1402,11 +1407,6 @@ class PySRRegressor(BaseEstimator, RegressorMixin, MultiOutputMixin):
                 "is enough to find a functional form with symbolic regression. "
                 "More datapoints will lower the search speed."
             )
-
-        # Parameter input validation (for parameters defined in __init__)
-        X, y, Xresampled, variable_names = self._validate_fit_params(
-            X, y, Xresampled, variable_names
-        )
 
         # Pre transformations (feature selection and denoising)
         X, y, variable_names = self._pre_transform_training_data(

--- a/pysr/version.py
+++ b/pysr/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.8.8"
+__version__ = "0.9.0"
 __symbolic_regression_jl_version__ = "0.9.6"

--- a/pysr/version.py
+++ b/pysr/version.py
@@ -1,2 +1,2 @@
 __version__ = "0.8.8"
-__symbolic_regression_jl_version__ = "0.9.5"
+__symbolic_regression_jl_version__ = "0.9.6"

--- a/pysr/version.py
+++ b/pysr/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.8.7"
-__symbolic_regression_jl_version__ = "0.9.4"
+__version__ = "0.8.8"
+__symbolic_regression_jl_version__ = "0.9.5"

--- a/test/test.py
+++ b/test/test.py
@@ -366,6 +366,12 @@ class TestMiscellaneous(unittest.TestCase):
             try:
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore")
+                    # To ensure an equation file is written for each output in
+                    # nout, set stop condition to niterations=1
+                    if check.func.__name__ == "check_regressor_multioutput":
+                        model.set_params(niterations=1, max_evals=None)
+                    else:
+                        model.set_params(max_evals=10000)
                     check(model)
                 print("Passed", check.func.__name__)
             except Exception as e:

--- a/test/test.py
+++ b/test/test.py
@@ -1,12 +1,10 @@
 import inspect
 import unittest
-from unittest.mock import patch
 import numpy as np
 from pysr import PySRRegressor
 from pysr.sr import run_feature_selection, _handle_feature_selection
 from sklearn.utils.estimator_checks import check_estimator
 import sympy
-from sympy import lambdify
 import pandas as pd
 import warnings
 
@@ -22,6 +20,7 @@ class TestPipeline(unittest.TestCase):
             inspect.signature(PySRRegressor.__init__).parameters["populations"].default
         )
         self.default_test_kwargs = dict(
+            progress=False,
             model_selection="accuracy",
             niterations=default_niterations * 2,
             populations=default_populations * 2,
@@ -235,6 +234,7 @@ class TestBest(unittest.TestCase):
         self.X = self.rstate.randn(10, 2)
         self.y = np.cos(self.X[:, 0]) ** 2
         self.model = PySRRegressor(
+            progress=False,
             niterations=1,
             extra_sympy_mappings={},
             output_jax_format=False,

--- a/test/test.py
+++ b/test/test.py
@@ -322,7 +322,7 @@ class TestMiscellaneous(unittest.TestCase):
 
     def test_size_warning(self):
         """Ensure that a warning is given for a large input size."""
-        model = PySRRegressor()
+        model = PySRRegressor(max_evals=10000, populations=2)
         X = np.random.randn(10001, 2)
         y = np.random.randn(10001)
         with warnings.catch_warnings():

--- a/test/test.py
+++ b/test/test.py
@@ -344,5 +344,18 @@ class TestMiscellaneous(unittest.TestCase):
 
     def test_scikit_learn_compatibility(self):
         """Test PySRRegressor compatibility with scikit-learn."""
-        model = PySRRegressor(max_evals=10000)  # Return early.
-        check_estimator(model)
+        model = PySRRegressor(
+            max_evals=10000, verbosity=0, progress=False
+        )  # Return early.
+        check_generator = check_estimator(model, generate_only=True)
+        for (_, check) in check_generator:
+            try:
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    check(model)
+                print("Passed", check.func.__name__)
+            except Exception as e:
+                print("Failed", check.func.__name__, "with:")
+                # Add a leading tab to error message, which
+                # might be multi-line:
+                print("\n".join([(" " * 4) + row for row in str(e).split("\n")]))

--- a/test/test.py
+++ b/test/test.py
@@ -348,18 +348,18 @@ class TestMiscellaneous(unittest.TestCase):
             max_evals=10000, verbosity=0, progress=False
         )  # Return early.
         check_generator = check_estimator(model, generate_only=True)
+        exception_messages = []
         for (_, check) in check_generator:
-            if "pickle" in check.func.__name__:
-                # Skip pickling tests.
-                continue
-
             try:
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore")
                     check(model)
                 print("Passed", check.func.__name__)
             except Exception as e:
+                exception_messages.append(f"{check.func.__name__}: {e}\n")
                 print("Failed", check.func.__name__, "with:")
                 # Add a leading tab to error message, which
                 # might be multi-line:
                 print("\n".join([(" " * 4) + row for row in str(e).split("\n")]))
+        # If any checks failed don't let the test pass.
+        self.assertEqual([], exception_messages)

--- a/test/test.py
+++ b/test/test.py
@@ -377,12 +377,22 @@ class TestMiscellaneous(unittest.TestCase):
                     and check.func.__name__ in tests_requiring_determinism
                 ):
                     # Skip test as PySR is not deterministic.
-                    continue
-
-                exception_messages.append(f"{check.func.__name__}: {error_message}\n")
-                print("Failed", check.func.__name__, "with:")
-                # Add a leading tab to error message, which
-                # might be multi-line:
-                print("\n".join([(" " * 4) + row for row in error_message.split("\n")]))
+                    print(
+                        "Failed",
+                        check.func.__name__,
+                        "which is an allowed failure, as the test requires determinism.",
+                    )
+                else:
+                    exception_messages.append(
+                        f"{check.func.__name__}: {error_message}\n"
+                    )
+                    print("Failed", check.func.__name__, "with:")
+                    # Add a leading tab to error message, which
+                    # might be multi-line:
+                    print(
+                        "\n".join(
+                            [(" " * 4) + row for row in error_message.split("\n")]
+                        )
+                    )
         # If any checks failed don't let the test pass.
         self.assertEqual([], exception_messages)

--- a/test/test.py
+++ b/test/test.py
@@ -358,6 +358,25 @@ class TestMiscellaneous(unittest.TestCase):
                 model.fit(X, y)
             self.assertIn("with 10 features or more", str(context.exception))
 
+    def test_deterministic_warnings(self):
+        """Ensure that warnings are given for determinism"""
+        model = PySRRegressor(random_state=0)
+        X = np.random.randn(100, 2)
+        y = np.random.randn(100)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with self.assertRaises(Exception) as context:
+                model.fit(X, y)
+            self.assertIn("`deterministic`", str(context.exception))
+
+    def test_deterministic_errors(self):
+        """Setting deterministic without random_state should error"""
+        model = PySRRegressor(deterministic=True)
+        X = np.random.randn(100, 2)
+        y = np.random.randn(100)
+        with self.assertRaises(ValueError):
+            model.fit(X, y)
+
     def test_scikit_learn_compatibility(self):
         """Test PySRRegressor compatibility with scikit-learn."""
         model = PySRRegressor(

--- a/test/test.py
+++ b/test/test.py
@@ -22,7 +22,7 @@ class TestPipeline(unittest.TestCase):
             inspect.signature(PySRRegressor.__init__).parameters["populations"].default
         )
         self.default_test_kwargs = dict(
-            model_selection="best",
+            model_selection="accuracy",
             niterations=default_niterations * 2,
             populations=default_populations * 2,
         )

--- a/test/test.py
+++ b/test/test.py
@@ -349,6 +349,10 @@ class TestMiscellaneous(unittest.TestCase):
         )  # Return early.
         check_generator = check_estimator(model, generate_only=True)
         for (_, check) in check_generator:
+            if "pickle" in check.func.__name__:
+                # Skip pickling tests.
+                continue
+
             try:
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore")

--- a/test/test.py
+++ b/test/test.py
@@ -348,19 +348,16 @@ class TestMiscellaneous(unittest.TestCase):
     def test_scikit_learn_compatibility(self):
         """Test PySRRegressor compatibility with scikit-learn."""
         model = PySRRegressor(
-            max_evals=10000, verbosity=0, progress=False
+            max_evals=10000,
+            verbosity=0,
+            progress=False,
+            random_state=0,
+            deterministic=True,
+            procs=0,
+            multithreading=False,
         )  # Return early.
 
-        # TODO: Add deterministic option so that we can test these.
-        # (would require backend changes, and procs=0 for serialism.)
         check_generator = check_estimator(model, generate_only=True)
-        tests_requiring_determinism = [
-            "check_regressors_int",  # PySR is not deterministic, so fails this.
-            "check_regressor_data_not_an_array",
-            "check_supervised_y_2d",
-            "check_regressors_int",
-            "check_fit_idempotent",
-        ]
         exception_messages = []
         for (_, check) in check_generator:
             try:
@@ -376,29 +373,10 @@ class TestMiscellaneous(unittest.TestCase):
                 print("Passed", check.func.__name__)
             except Exception as e:
                 error_message = str(e)
-                failed_tolerance_check = "Not equal to tolerance" in error_message
-
-                if (
-                    failed_tolerance_check
-                    and check.func.__name__ in tests_requiring_determinism
-                ):
-                    # Skip test as PySR is not deterministic.
-                    print(
-                        "Failed",
-                        check.func.__name__,
-                        "which is an allowed failure, as the test requires determinism.",
-                    )
-                else:
-                    exception_messages.append(
-                        f"{check.func.__name__}: {error_message}\n"
-                    )
-                    print("Failed", check.func.__name__, "with:")
-                    # Add a leading tab to error message, which
-                    # might be multi-line:
-                    print(
-                        "\n".join(
-                            [(" " * 4) + row for row in error_message.split("\n")]
-                        )
-                    )
+                exception_messages.append(f"{check.func.__name__}: {error_message}\n")
+                print("Failed", check.func.__name__, "with:")
+                # Add a leading tab to error message, which
+                # might be multi-line:
+                print("\n".join([(" " * 4) + row for row in error_message.split("\n")]))
         # If any checks failed don't let the test pass.
         self.assertEqual([], exception_messages)

--- a/test/test.py
+++ b/test/test.py
@@ -231,6 +231,17 @@ class TestPipeline(unittest.TestCase):
 
 class TestBest(unittest.TestCase):
     def setUp(self):
+        self.rstate = np.random.RandomState(0)
+        self.X = self.rstate.randn(10, 2)
+        self.y = np.cos(self.X[:, 0]) ** 2
+        self.model = PySRRegressor(
+            niterations=1,
+            extra_sympy_mappings={},
+            output_jax_format=False,
+            model_selection="accuracy",
+            equation_file="equation_file.csv",
+        )
+        self.model.fit(self.X, self.y)
         equations = pd.DataFrame(
             {
                 "equation": ["1.0", "cos(x0)", "square(cos(x0))"],
@@ -243,18 +254,6 @@ class TestBest(unittest.TestCase):
             "equation_file.csv.bkup", sep="|"
         )
 
-        self.model = PySRRegressor(
-            equation_file="equation_file.csv",
-            variable_names="x0 x1".split(" "),
-            extra_sympy_mappings={},
-            output_jax_format=False,
-            model_selection="accuracy",
-        )
-        self.rstate = np.random.RandomState(0)
-        # Placeholder values needed to fit the model from an equation file
-        self.X = self.rstate.randn(10, 2)
-        self.y = np.cos(self.X[:, 0]) ** 2
-        self.model.fit(self.X, self.y, from_equation_file=True)
         self.model.refresh()
         self.equations_ = self.model.equations_
 
@@ -307,6 +306,10 @@ class TestFeatureSelection(unittest.TestCase):
 
 class TestMiscellaneous(unittest.TestCase):
     """Test miscellaneous functions."""
+
+    def setUp(self):
+        # Allows all scikit-learn exception messages to be read.
+        self.maxDiff = None
 
     def test_deprecation(self):
         """Ensure that deprecation works as expected.

--- a/test/test.py
+++ b/test/test.py
@@ -343,5 +343,5 @@ class TestMiscellaneous(unittest.TestCase):
 
     def test_scikit_learn_compatibility(self):
         """Test PySRRegressor compatibility with scikit-learn."""
-        model = PySRRegressor()
+        model = PySRRegressor(max_evals=10000)  # Return early.
         check_estimator(model)

--- a/test/test.py
+++ b/test/test.py
@@ -118,7 +118,7 @@ class TestPipeline(unittest.TestCase):
             print("Model equations: ", model.sympy()[1])
             print("True equation: x1^2")
 
-    def test_empty_operators_single_input_multirun(self):
+    def test_empty_operators_single_input_warm_start(self):
         X = self.rstate.randn(100, 1)
         y = X[:, 0] + 3.0
         regressor = PySRRegressor(
@@ -135,7 +135,8 @@ class TestPipeline(unittest.TestCase):
         np.testing.assert_almost_equal(regressor.predict(X), y, decimal=1)
 
         # Test if repeated fit works:
-        regressor.set_params(niterations=0)
+        regressor.set_params(niterations=0, warm_start=True)
+        # This should exit immediately, and use the old equations
         regressor.fit(X, y)
 
         self.assertLessEqual(regressor.equations_.iloc[-1]["loss"], 1e-4)

--- a/test/test_jax.py
+++ b/test/test_jax.py
@@ -23,6 +23,13 @@ class TestJAX(unittest.TestCase):
 
     def test_pipeline_pandas(self):
         X = pd.DataFrame(np.random.randn(100, 10))
+        y = np.ones(X.shape[0])
+        model = PySRRegressor(
+            max_evals=10000,
+            output_jax_format=True,
+        )
+        model.fit(X, y)
+
         equations = pd.DataFrame(
             {
                 "Equation": ["1.0", "cos(x1)", "square(cos(x1))"],
@@ -35,14 +42,7 @@ class TestJAX(unittest.TestCase):
             "equation_file.csv.bkup", sep="|"
         )
 
-        model = PySRRegressor(
-            equation_file="equation_file.csv",
-            output_jax_format=True,
-            variable_names="x1 x2 x3".split(" "),
-        )
-
-        model.fit(X, y=np.ones(X.shape[0]), from_equation_file=True)
-        model.refresh()
+        model.refresh(checkpoint_file="equation_file.csv")
         jformat = model.jax()
 
         np.testing.assert_almost_equal(
@@ -53,6 +53,10 @@ class TestJAX(unittest.TestCase):
 
     def test_pipeline(self):
         X = np.random.randn(100, 10)
+        y = np.ones(X.shape[0])
+        model = PySRRegressor(max_evals=10000, output_jax_format=True)
+        model.fit(X, y)
+
         equations = pd.DataFrame(
             {
                 "Equation": ["1.0", "cos(x1)", "square(cos(x1))"],
@@ -65,14 +69,7 @@ class TestJAX(unittest.TestCase):
             "equation_file.csv.bkup", sep="|"
         )
 
-        model = PySRRegressor(
-            equation_file="equation_file.csv",
-            output_jax_format=True,
-            variable_names="x1 x2 x3".split(" "),
-        )
-
-        model.fit(X, y=np.ones(X.shape[0]), from_equation_file=True)
-        model.refresh()
+        model.refresh(checkpoint_file="equation_file.csv")
         jformat = model.jax()
 
         np.testing.assert_almost_equal(

--- a/test/test_jax.py
+++ b/test/test_jax.py
@@ -25,6 +25,7 @@ class TestJAX(unittest.TestCase):
         X = pd.DataFrame(np.random.randn(100, 10))
         y = np.ones(X.shape[0])
         model = PySRRegressor(
+            progress=False,
             max_evals=10000,
             output_jax_format=True,
         )
@@ -54,7 +55,7 @@ class TestJAX(unittest.TestCase):
     def test_pipeline(self):
         X = np.random.randn(100, 10)
         y = np.ones(X.shape[0])
-        model = PySRRegressor(max_evals=10000, output_jax_format=True)
+        model = PySRRegressor(progress=False, max_evals=10000, output_jax_format=True)
         model.fit(X, y)
 
         equations = pd.DataFrame(
@@ -83,7 +84,10 @@ class TestJAX(unittest.TestCase):
         y = X["k15"] ** 2 + np.cos(X["k20"])
 
         model = PySRRegressor(
-            unary_operators=["cos"], select_k_features=3, early_stop_condition=1e-5
+            progress=False,
+            unary_operators=["cos"],
+            select_k_features=3,
+            early_stop_condition=1e-5,
         )
         model.fit(X.values, y.values)
         f, parameters = model.jax().values()

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2,7 +2,6 @@ import unittest
 import numpy as np
 import pandas as pd
 from pysr import sympy2torch, PySRRegressor
-import torch
 import sympy
 from functools import partial
 
@@ -14,6 +13,8 @@ class TestTorch(unittest.TestCase):
     def test_sympy2torch(self):
         x, y, z = sympy.symbols("x y z")
         cosx = 1.0 * sympy.cos(x) + y
+
+        import torch
         X = torch.tensor(np.random.randn(1000, 3))
         true = 1.0 * torch.cos(X[:, 0]) + X[:, 1]
         torch_module = sympy2torch(cosx, [x, y, z])
@@ -49,6 +50,8 @@ class TestTorch(unittest.TestCase):
 
         tformat = model.pytorch()
         self.assertEqual(str(tformat), "_SingleSymPyModule(expression=cos(x1)**2)")
+        import torch
+
         np.testing.assert_almost_equal(
             tformat(torch.tensor(X.values)).detach().numpy(),
             np.square(np.cos(X.values[:, 1])),  # Selection 1st feature
@@ -81,6 +84,8 @@ class TestTorch(unittest.TestCase):
 
         tformat = model.pytorch()
         self.assertEqual(str(tformat), "_SingleSymPyModule(expression=cos(x1)**2)")
+
+        import torch
         np.testing.assert_almost_equal(
             tformat(torch.tensor(X)).detach().numpy(),
             np.square(np.cos(X[:, 1])),  # 2nd feature
@@ -93,6 +98,7 @@ class TestTorch(unittest.TestCase):
 
         module = sympy2torch(expression, [x, y, z])
 
+        import torch
         X = torch.rand(100, 3).float() * 10
 
         true_out = (
@@ -133,6 +139,7 @@ class TestTorch(unittest.TestCase):
 
         tformat = model.pytorch()
         self.assertEqual(str(tformat), "_SingleSymPyModule(expression=sin(x1))")
+        import torch
         np.testing.assert_almost_equal(
             tformat(torch.tensor(X)).detach().numpy(),
             np.sin(X[:, 1]),
@@ -152,6 +159,7 @@ class TestTorch(unittest.TestCase):
         torch_module = model.pytorch()
 
         np_output = model.predict(X.values)
+        import torch
         torch_output = torch_module(torch.tensor(X.values)).detach().numpy()
 
         np.testing.assert_almost_equal(np_output, torch_output, decimal=4)

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -125,6 +125,7 @@ class TestTorch(unittest.TestCase):
             "equation_file_custom_operator.csv.bkup", sep="|"
         )
 
+        import torch
         model = PySRRegressor(
             model_selection="accuracy",
             equation_file="equation_file_custom_operator.csv",
@@ -139,7 +140,6 @@ class TestTorch(unittest.TestCase):
 
         tformat = model.pytorch()
         self.assertEqual(str(tformat), "_SingleSymPyModule(expression=sin(x1))")
-        import torch
         np.testing.assert_almost_equal(
             tformat(torch.tensor(X)).detach().numpy(),
             np.sin(X[:, 1]),

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -23,6 +23,16 @@ class TestTorch(unittest.TestCase):
         )
 
     def test_pipeline_pandas(self):
+        X = pd.DataFrame(np.random.randn(100, 10))
+        y = np.ones(X.shape[0])
+        model = PySRRegressor(
+            max_evals=10000,
+            model_selection="accuracy",
+            extra_sympy_mappings={},
+            output_torch_format=True,
+        )
+        model.fit(X, y)
+
         equations = pd.DataFrame(
             {
                 "Equation": ["1.0", "cos(x1)", "square(cos(x1))"],
@@ -35,15 +45,6 @@ class TestTorch(unittest.TestCase):
             "equation_file.csv.bkup", sep="|"
         )
 
-        X = pd.DataFrame(np.random.randn(100, 10))
-        y = np.ones(X.shape[0])
-        model = PySRRegressor(
-            max_evals=10000,
-            model_selection="accuracy",
-            extra_sympy_mappings={},
-            output_torch_format=True,
-        )
-        model.fit(X, y)
         model.refresh(checkpoint_file="equation_file.csv")
         tformat = model.pytorch()
         self.assertEqual(str(tformat), "_SingleSymPyModule(expression=cos(x1)**2)")

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2,10 +2,13 @@ import unittest
 import numpy as np
 import pandas as pd
 from pysr import sympy2torch, PySRRegressor
+
 # Need to initialize Julia before importing torch...
 import platform
+
 if platform.system() == "Darwin":
     from pysr.julia_helpers import init_julia
+
     Main = init_julia()
     import torch
 else:

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -3,9 +3,15 @@ import numpy as np
 import pandas as pd
 from pysr import sympy2torch, PySRRegressor
 # Need to initialize Julia before importing torch...
-from pysr.julia_helpers import init_julia
-Main = init_julia()
-import torch
+import platform
+if platform.system() == "Darwin":
+    from pysr.julia_helpers import init_julia
+    Main = init_julia()
+    import torch
+else:
+    # Switch order of imports.
+    # https://github.com/pytorch/pytorch/issues/78829
+    import torch
 import sympy
 
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -2,6 +2,10 @@ import unittest
 import numpy as np
 import pandas as pd
 from pysr import sympy2torch, PySRRegressor
+# Need to initialize Julia before importing torch...
+from pysr.julia_helpers import init_julia
+Main = init_julia()
+import torch
 import sympy
 
 
@@ -12,8 +16,6 @@ class TestTorch(unittest.TestCase):
     def test_sympy2torch(self):
         x, y, z = sympy.symbols("x y z")
         cosx = 1.0 * sympy.cos(x) + y
-
-        import torch
 
         X = torch.tensor(np.random.randn(1000, 3))
         true = 1.0 * torch.cos(X[:, 0]) + X[:, 1]
@@ -49,7 +51,6 @@ class TestTorch(unittest.TestCase):
         model.refresh(checkpoint_file="equation_file.csv")
         tformat = model.pytorch()
         self.assertEqual(str(tformat), "_SingleSymPyModule(expression=cos(x1)**2)")
-        import torch
 
         np.testing.assert_almost_equal(
             tformat(torch.tensor(X.values)).detach().numpy(),
@@ -85,8 +86,6 @@ class TestTorch(unittest.TestCase):
         tformat = model.pytorch()
         self.assertEqual(str(tformat), "_SingleSymPyModule(expression=cos(x1)**2)")
 
-        import torch
-
         np.testing.assert_almost_equal(
             tformat(torch.tensor(X)).detach().numpy(),
             np.square(np.cos(X[:, 1])),  # 2nd feature
@@ -98,8 +97,6 @@ class TestTorch(unittest.TestCase):
         expression = x**2 + sympy.atanh(sympy.Mod(y + 1, 2) - 1) * 3.2 * z
 
         module = sympy2torch(expression, [x, y, z])
-
-        import torch
 
         X = torch.rand(100, 3).float() * 10
 
@@ -135,8 +132,6 @@ class TestTorch(unittest.TestCase):
             "equation_file_custom_operator.csv.bkup", sep="|"
         )
 
-        import torch
-
         model.set_params(
             equation_file="equation_file_custom_operator.csv",
             extra_sympy_mappings={"mycustomoperator": sympy.sin},
@@ -168,7 +163,6 @@ class TestTorch(unittest.TestCase):
         torch_module = model.pytorch()
 
         np_output = model.predict(X.values)
-        import torch
 
         torch_output = torch_module(torch.tensor(X.values)).detach().numpy()
 

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -26,6 +26,7 @@ class TestTorch(unittest.TestCase):
         X = pd.DataFrame(np.random.randn(100, 10))
         y = np.ones(X.shape[0])
         model = PySRRegressor(
+            progress=False,
             max_evals=10000,
             model_selection="accuracy",
             extra_sympy_mappings={},
@@ -60,6 +61,7 @@ class TestTorch(unittest.TestCase):
         X = np.random.randn(100, 10)
         y = np.ones(X.shape[0])
         model = PySRRegressor(
+            progress=False,
             max_evals=10000,
             model_selection="accuracy",
             output_torch_format=True,
@@ -114,6 +116,7 @@ class TestTorch(unittest.TestCase):
         X = np.random.randn(100, 3)
         y = np.ones(X.shape[0])
         model = PySRRegressor(
+            progress=False,
             max_evals=10000,
             model_selection="accuracy",
             output_torch_format=True,
@@ -156,6 +159,7 @@ class TestTorch(unittest.TestCase):
         y = X["k15"] ** 2 + np.cos(X["k20"])
 
         model = PySRRegressor(
+            progress=False,
             unary_operators=["cos"],
             select_k_features=3,
             early_stop_condition=1e-5,

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -7,12 +7,13 @@ from pysr import sympy2torch, PySRRegressor
 import platform
 
 if platform.system() == "Darwin":
+    # Import PyJulia, then Torch
     from pysr.julia_helpers import init_julia
 
     Main = init_julia()
     import torch
 else:
-    # Switch order of imports.
+    # Import Torch, then PyJulia
     # https://github.com/pytorch/pytorch/issues/78829
     import torch
 import sympy


### PR DESCRIPTION
Re Issue #143

Compatibility with scikit-learn should be improved. 

Noteable breaking changes for users: `PySRRegressor.equations` is now called `PySRRegressor.equations_`

Tests have been updated to allow compatibility with the refactored code but still assess the same functionality. All tests should pass.

Please let me know if there are any concerns or if you would like me to document/explain any of the changes in detail. 