### PR TITLE
[Feature] LaTeX table generator

### DIFF
--- a/pysr/export_latex.py
+++ b/pysr/export_latex.py
@@ -6,21 +6,24 @@ from sympy.printing.latex import LatexPrinter
 class PreciseLatexPrinter(LatexPrinter):
     """Modified SymPy printer with custom float precision."""
 
-    def __init__(self, settings=None, prec=3):
+    def __init__(self, settings=None, prec=3, full_prec=True):
         super().__init__(settings)
         self.prec = prec
+        self.full_prec = full_prec
 
     def _print_Float(self, expr):
         # Reduce precision of float:
-        reduced_float = sympy.Float(expr, self.prec)
+        reduced_float = sympy.Float(expr, self.prec, full_prec=self.full_prec)
         return super()._print_Float(reduced_float)
 
 
-def to_latex(expr, prec=3, **settings):
+def to_latex(expr, prec=3, full_prec=True, **settings):
     """Convert sympy expression to LaTeX with custom precision."""
     if len(settings) == 0:
         settings = None
-    printer = PreciseLatexPrinter(settings=settings, prec=prec)
+    printer = PreciseLatexPrinter(
+        settings=settings, prec=prec, full_prec=full_prec
+    )
     return printer.doprint(expr)
 
 

--- a/pysr/export_latex.py
+++ b/pysr/export_latex.py
@@ -21,9 +21,7 @@ def to_latex(expr, prec=3, full_prec=True, **settings):
     """Convert sympy expression to LaTeX with custom precision."""
     if len(settings) == 0:
         settings = None
-    printer = PreciseLatexPrinter(
-        settings=settings, prec=prec, full_prec=full_prec
-    )
+    printer = PreciseLatexPrinter(settings=settings, prec=prec, full_prec=full_prec)
     return printer.doprint(expr)
 
 

--- a/pysr/export_latex.py
+++ b/pysr/export_latex.py
@@ -6,22 +6,20 @@ from sympy.printing.latex import LatexPrinter
 class PreciseLatexPrinter(LatexPrinter):
     """Modified SymPy printer with custom float precision."""
 
-    def __init__(self, settings=None, prec=3, full_prec=True):
+    def __init__(self, settings=None, prec=3):
         super().__init__(settings)
         self.prec = prec
-        self.full_prec = full_prec
 
     def _print_Float(self, expr):
         # Reduce precision of float:
-        reduced_float = sympy.Float(expr, self.prec, full_prec=self.full_prec)
+        reduced_float = sympy.Float(expr, self.prec)
         return super()._print_Float(reduced_float)
 
 
 def to_latex(expr, prec=3, full_prec=True, **settings):
     """Convert sympy expression to LaTeX with custom precision."""
-    if len(settings) == 0:
-        settings = None
-    printer = PreciseLatexPrinter(settings=settings, prec=prec, full_prec=full_prec)
+    settings["full_prec"] = full_prec
+    printer = PreciseLatexPrinter(settings=settings, prec=prec)
     return printer.doprint(expr)
 
 

--- a/pysr/export_latex.py
+++ b/pysr/export_latex.py
@@ -1,0 +1,34 @@
+"""Functions to help export PySR equations to LaTeX."""
+import re
+
+
+def set_precision_of_constants_in_string(s, precision=3):
+    """Set precision of constants in string."""
+    constants = re.findall(r"\b[-+]?\d*\.\d+|\b[-+]?\d+\.?\d*", s)
+    for c in constants:
+        reduced_c = "{:.{precision}g}".format(float(c), precision=precision)
+        s = s.replace(c, reduced_c)
+    return s
+
+
+def generate_top_of_latex_table():
+    latex_table_pieces = [
+        r"\begin{table}[h]",
+        r"\centering",
+        r"\caption{}",
+        r"\label{}",
+        r"\begin{tabular}{@{}lcc@{}}",
+        r"\toprule",
+        r"Equation & Complexity & Loss \\",
+        r"\midrule",
+    ]
+    return "\n".join(latex_table_pieces)
+
+
+def generate_bottom_of_latex_table():
+    latex_table_pieces = [
+        r"\bottomrule",
+        r"\end{tabular}",
+        r"\end{table}",
+    ]
+    return "\n".join(latex_table_pieces)

--- a/pysr/export_latex.py
+++ b/pysr/export_latex.py
@@ -55,61 +55,72 @@ def generate_table_environment(columns=["equation", "complexity", "loss"]):
     return top_latex_table, bottom_latex_table
 
 
-def generate_table(
-    equations: List[pd.DataFrame],
-    indices: List[List[int]],
-    precision=3,
+def generate_single_table(
+    equations: pd.DataFrame,
+    indices: List[int] = None,
+    precision: int = 3,
     columns=["equation", "complexity", "loss", "score"],
 ):
-    latex_top, latex_bottom = generate_table_environment(columns)
+    assert isinstance(equations, pd.DataFrame)
 
-    latex_equations = [
-        [to_latex(eq, prec=precision) for eq in equation_set["sympy_format"]]
-        for equation_set in equations
+    latex_top, latex_bottom = generate_table_environment(columns)
+    latex_table_content = []
+
+    if indices is None:
+        indices = range(len(equations))
+
+    for i in indices:
+        latex_equation = to_latex(
+            equations.iloc[i]["sympy_format"],
+            prec=precision,
+        )
+        complexity = str(equations.iloc[i]["complexity"])
+        loss = to_latex(
+            sympy.Float(equations.iloc[i]["loss"]),
+            prec=precision,
+        )
+        score = to_latex(
+            sympy.Float(equations.iloc[i]["score"]),
+            prec=precision,
+        )
+
+        row_pieces = []
+        for col in columns:
+            if col == "equation":
+                row_pieces.append(latex_equation)
+            elif col == "complexity":
+                row_pieces.append(complexity)
+            elif col == "loss":
+                row_pieces.append(loss)
+            elif col == "score":
+                row_pieces.append(score)
+            else:
+                raise ValueError(f"Unknown column: {col}")
+
+        row_pieces = ["$" + piece + "$" for piece in row_pieces]
+
+        latex_table_content.append(
+            " & ".join(row_pieces) + r" \\",
+        )
+
+    return "\n".join([latex_top, *latex_table_content, latex_bottom])
+
+
+def generate_multiple_tables(
+    equations: List[pd.DataFrame],
+    indices: List[List[int]] = None,
+    precision: int = 3,
+    columns=["equation", "complexity", "loss", "score"],
+):
+
+    latex_tables = [
+        generate_single_table(
+            equations[i],
+            (None if not indices else indices[i]),
+            precision=precision,
+            columns=columns,
+        )
+        for i in range(len(equations))
     ]
 
-    all_latex_table_str = []
-
-    for output_feature, index_set in enumerate(indices):
-        latex_table_content = []
-        for i in index_set:
-            latex_equation = latex_equations[output_feature][i]
-            complexity = str(equations[output_feature].iloc[i]["complexity"])
-            loss = to_latex(
-                sympy.Float(equations[output_feature].iloc[i]["loss"]),
-                prec=precision,
-            )
-            score = to_latex(
-                sympy.Float(equations[output_feature].iloc[i]["score"]),
-                prec=precision,
-            )
-
-            row_pieces = []
-            for col in columns:
-                if col == "equation":
-                    row_pieces.append(latex_equation)
-                elif col == "complexity":
-                    row_pieces.append(complexity)
-                elif col == "loss":
-                    row_pieces.append(loss)
-                elif col == "score":
-                    row_pieces.append(score)
-                else:
-                    raise ValueError(f"Unknown column: {col}")
-
-            row_pieces = ["$" + piece + "$" for piece in row_pieces]
-
-            latex_table_content.append(
-                " & ".join(row_pieces) + r" \\",
-            )
-
-        this_latex_table = "\n".join(
-            [
-                latex_top,
-                *latex_table_content,
-                latex_bottom,
-            ]
-        )
-        all_latex_table_str.append(this_latex_table)
-
-    return "\n\n".join(all_latex_table_str)
+    return "\n\n".join(latex_tables)

--- a/pysr/export_latex.py
+++ b/pysr/export_latex.py
@@ -5,6 +5,7 @@ from sympy.printing.latex import LatexPrinter
 
 class PreciseLatexPrinter(LatexPrinter):
     """Modified SymPy printer with custom float precision."""
+
     def __init__(self, settings=None, prec=3):
         super().__init__(settings)
         self.prec = prec

--- a/pysr/export_latex.py
+++ b/pysr/export_latex.py
@@ -11,13 +11,14 @@ def set_precision_of_constants_in_string(s, precision=3):
     return s
 
 
-def generate_top_of_latex_table():
+def generate_top_of_latex_table(columns=["Equation", "Complexity", "Loss"]):
+    margins = "".join([("c" if col == "Equation" else "l") for col in columns])
     latex_table_pieces = [
         r"\begin{table}[h]",
         r"\begin{center}",
-        r"\begin{tabular}{@{}lcc@{}}",
+        r"\begin{tabular}{@{}" + margins + r"@{}}",
         r"\toprule",
-        r"Equation & Complexity & Loss \\",
+        " & ".join(columns) + r" \\",
         r"\midrule",
     ]
     return "\n".join(latex_table_pieces)

--- a/pysr/export_latex.py
+++ b/pysr/export_latex.py
@@ -6,9 +6,6 @@ from typing import List
 import warnings
 
 
-raised_long_equation_warning = False
-
-
 class PreciseLatexPrinter(LatexPrinter):
     """Modified SymPy printer with custom float precision."""
 
@@ -70,8 +67,6 @@ def generate_single_table(
     """Generate a booktabs-style LaTeX table for a single set of equations."""
     assert isinstance(equations, pd.DataFrame)
 
-    global raised_long_equation_warning
-
     latex_top, latex_bottom = generate_table_environment(columns)
     latex_table_content = []
 
@@ -101,11 +96,6 @@ def generate_single_table(
                         "$" + output_variable_name + " = " + latex_equation + "$"
                     )
                 else:
-                    if not raised_long_equation_warning:
-                        warnings.warn(
-                            "Please add \\usepackage{breqn} to your LaTeX preamble."
-                        )
-                        raised_long_equation_warning = True
 
                     broken_latex_equation = " ".join(
                         [

--- a/pysr/export_latex.py
+++ b/pysr/export_latex.py
@@ -61,6 +61,7 @@ def generate_single_table(
     precision: int = 3,
     columns=["equation", "complexity", "loss", "score"],
 ):
+    """Generate a booktabs-style LaTeX table for a single set of equations."""
     assert isinstance(equations, pd.DataFrame)
 
     latex_top, latex_bottom = generate_table_environment(columns)
@@ -112,6 +113,7 @@ def generate_multiple_tables(
     precision: int = 3,
     columns=["equation", "complexity", "loss", "score"],
 ):
+    """Generate multiple latex tables for a list of equation sets."""
 
     latex_tables = [
         generate_single_table(

--- a/pysr/export_latex.py
+++ b/pysr/export_latex.py
@@ -60,6 +60,7 @@ def generate_single_table(
     indices: List[int] = None,
     precision: int = 3,
     columns=["equation", "complexity", "loss", "score"],
+    max_equation_length: int = 50,
 ):
     """Generate a booktabs-style LaTeX table for a single set of equations."""
     assert isinstance(equations, pd.DataFrame)
@@ -88,17 +89,32 @@ def generate_single_table(
         row_pieces = []
         for col in columns:
             if col == "equation":
-                row_pieces.append(latex_equation)
+                if len(latex_equation) < max_equation_length:
+                    row_pieces.append("$" + latex_equation + "$")
+                else:
+                    broken_latex_equation = " ".join(
+                        [
+                            r"\vbox{",
+                            r"\vspace{-1em}",
+                            r"\begin{flushleft}",
+                            r"$\displaystyle",
+                            latex_equation,
+                            "$",
+                            r"\end{flushleft}",
+                            r"\vspace{-1em}",
+                            "}",
+                        ]
+                    )
+                    row_pieces.append(broken_latex_equation)
+
             elif col == "complexity":
-                row_pieces.append(complexity)
+                row_pieces.append("$" + complexity + "$")
             elif col == "loss":
-                row_pieces.append(loss)
+                row_pieces.append("$" + loss + "$")
             elif col == "score":
-                row_pieces.append(score)
+                row_pieces.append("$" + score + "$")
             else:
                 raise ValueError(f"Unknown column: {col}")
-
-        row_pieces = ["$" + piece + "$" for piece in row_pieces]
 
         latex_table_content.append(
             " & ".join(row_pieces) + r" \\",

--- a/pysr/export_latex.py
+++ b/pysr/export_latex.py
@@ -23,7 +23,7 @@ def to_latex(expr, prec=3, full_prec=True, **settings):
     return printer.doprint(expr)
 
 
-def generate_top_of_latex_table(columns=["equation", "complexity", "loss"]):
+def generate_table_environment(columns=["equation", "complexity", "loss"]):
     margins = "".join([("l" if col == "equation" else "c") for col in columns])
     column_map = {
         "complexity": "Complexity",
@@ -32,7 +32,7 @@ def generate_top_of_latex_table(columns=["equation", "complexity", "loss"]):
         "score": "Score",
     }
     columns = [column_map[col] for col in columns]
-    latex_table_pieces = [
+    top_pieces = [
         r"\begin{table}[h]",
         r"\begin{center}",
         r"\begin{tabular}{@{}" + margins + r"@{}}",
@@ -40,14 +40,14 @@ def generate_top_of_latex_table(columns=["equation", "complexity", "loss"]):
         " & ".join(columns) + r" \\",
         r"\midrule",
     ]
-    return "\n".join(latex_table_pieces)
 
-
-def generate_bottom_of_latex_table():
-    latex_table_pieces = [
+    bottom_pieces = [
         r"\bottomrule",
         r"\end{tabular}",
         r"\end{center}",
         r"\end{table}",
     ]
-    return "\n".join(latex_table_pieces)
+    top_latex_table = "\n".join(top_pieces)
+    bottom_latex_table = "\n".join(bottom_pieces)
+
+    return top_latex_table, bottom_latex_table

--- a/pysr/export_latex.py
+++ b/pysr/export_latex.py
@@ -65,6 +65,7 @@ def generate_single_table(
     precision: int = 3,
     columns=["equation", "complexity", "loss", "score"],
     max_equation_length: int = 50,
+    output_variable_name: str = "y",
 ):
     """Generate a booktabs-style LaTeX table for a single set of equations."""
     assert isinstance(equations, pd.DataFrame)
@@ -96,7 +97,9 @@ def generate_single_table(
         for col in columns:
             if col == "equation":
                 if len(latex_equation) < max_equation_length:
-                    row_pieces.append("$" + latex_equation + "$")
+                    row_pieces.append(
+                        "$" + output_variable_name + " = " + latex_equation + "$"
+                    )
                 else:
                     if not raised_long_equation_warning:
                         warnings.warn(
@@ -109,7 +112,7 @@ def generate_single_table(
                             r"\begin{minipage}{0.8\linewidth}",
                             r"\vspace{-1em}",
                             r"\begin{dmath*}",
-                            latex_equation,
+                            output_variable_name + " = " + latex_equation,
                             r"\end{dmath*}",
                             r"\end{minipage}",
                         ]
@@ -137,8 +140,10 @@ def generate_multiple_tables(
     indices: List[List[int]] = None,
     precision: int = 3,
     columns=["equation", "complexity", "loss", "score"],
+    output_variable_names: str = None,
 ):
     """Generate multiple latex tables for a list of equation sets."""
+    # TODO: Let user specify custom output variable
 
     latex_tables = [
         generate_single_table(
@@ -146,6 +151,11 @@ def generate_multiple_tables(
             (None if not indices else indices[i]),
             precision=precision,
             columns=columns,
+            output_variable_name=(
+                "y_{" + str(i) + "}"
+                if output_variable_names is None
+                else output_variable_names[i]
+            ),
         )
         for i in range(len(equations))
     ]

--- a/pysr/export_latex.py
+++ b/pysr/export_latex.py
@@ -14,9 +14,7 @@ def set_precision_of_constants_in_string(s, precision=3):
 def generate_top_of_latex_table():
     latex_table_pieces = [
         r"\begin{table}[h]",
-        r"\centering",
-        r"\caption{}",
-        r"\label{}",
+        r"\begin{center}",
         r"\begin{tabular}{@{}lcc@{}}",
         r"\toprule",
         r"Equation & Complexity & Loss \\",
@@ -29,6 +27,7 @@ def generate_bottom_of_latex_table():
     latex_table_pieces = [
         r"\bottomrule",
         r"\end{tabular}",
+        r"\end{center}",
         r"\end{table}",
     ]
     return "\n".join(latex_table_pieces)

--- a/pysr/export_latex.py
+++ b/pysr/export_latex.py
@@ -23,8 +23,15 @@ def to_latex(expr, prec=3, full_prec=True, **settings):
     return printer.doprint(expr)
 
 
-def generate_top_of_latex_table(columns=["Equation", "Complexity", "Loss"]):
-    margins = "".join([("l" if col == "Equation" else "c") for col in columns])
+def generate_top_of_latex_table(columns=["equation", "complexity", "loss"]):
+    margins = "".join([("l" if col == "equation" else "c") for col in columns])
+    column_map = {
+        "complexity": "Complexity",
+        "loss": "Loss",
+        "equation": "Equation",
+        "score": "Score",
+    }
+    columns = [column_map[col] for col in columns]
     latex_table_pieces = [
         r"\begin{table}[h]",
         r"\begin{center}",

--- a/pysr/export_latex.py
+++ b/pysr/export_latex.py
@@ -1,14 +1,26 @@
 """Functions to help export PySR equations to LaTeX."""
-import re
+import sympy
+from sympy.printing.latex import LatexPrinter
 
 
-def set_precision_of_constants_in_string(s, precision=3):
-    """Set precision of constants in string."""
-    constants = re.findall(r"\b[-+]?\d*\.\d+|\b[-+]?\d+\.?\d*", s)
-    for c in constants:
-        reduced_c = "{:.{precision}g}".format(float(c), precision=precision)
-        s = s.replace(c, reduced_c)
-    return s
+class PreciseLatexPrinter(LatexPrinter):
+    """Modified SymPy printer with custom float precision."""
+    def __init__(self, settings=None, prec=3):
+        super().__init__(settings)
+        self.prec = prec
+
+    def _print_Float(self, expr):
+        # Reduce precision of float:
+        reduced_float = sympy.Float(expr, self.prec)
+        return super()._print_Float(reduced_float)
+
+
+def to_latex(expr, prec=3, **settings):
+    """Convert sympy expression to LaTeX with custom precision."""
+    if len(settings) == 0:
+        settings = None
+    printer = PreciseLatexPrinter(settings=settings, prec=prec)
+    return printer.doprint(expr)
 
 
 def generate_top_of_latex_table(columns=["Equation", "Complexity", "Loss"]):

--- a/pysr/export_latex.py
+++ b/pysr/export_latex.py
@@ -1,6 +1,8 @@
 """Functions to help export PySR equations to LaTeX."""
 import sympy
 from sympy.printing.latex import LatexPrinter
+import pandas as pd
+from typing import List
 
 
 class PreciseLatexPrinter(LatexPrinter):
@@ -51,3 +53,63 @@ def generate_table_environment(columns=["equation", "complexity", "loss"]):
     bottom_latex_table = "\n".join(bottom_pieces)
 
     return top_latex_table, bottom_latex_table
+
+
+def generate_table(
+    equations: List[pd.DataFrame],
+    indices: List[List[int]],
+    precision=3,
+    columns=["equation", "complexity", "loss", "score"],
+):
+    latex_top, latex_bottom = generate_table_environment(columns)
+
+    latex_equations = [
+        [to_latex(eq, prec=precision) for eq in equation_set["sympy_format"]]
+        for equation_set in equations
+    ]
+
+    all_latex_table_str = []
+
+    for output_feature, index_set in enumerate(indices):
+        latex_table_content = []
+        for i in index_set:
+            latex_equation = latex_equations[output_feature][i]
+            complexity = str(equations[output_feature].iloc[i]["complexity"])
+            loss = to_latex(
+                sympy.Float(equations[output_feature].iloc[i]["loss"]),
+                prec=precision,
+            )
+            score = to_latex(
+                sympy.Float(equations[output_feature].iloc[i]["score"]),
+                prec=precision,
+            )
+
+            row_pieces = []
+            for col in columns:
+                if col == "equation":
+                    row_pieces.append(latex_equation)
+                elif col == "complexity":
+                    row_pieces.append(complexity)
+                elif col == "loss":
+                    row_pieces.append(loss)
+                elif col == "score":
+                    row_pieces.append(score)
+                else:
+                    raise ValueError(f"Unknown column: {col}")
+
+            row_pieces = ["$" + piece + "$" for piece in row_pieces]
+
+            latex_table_content.append(
+                " & ".join(row_pieces) + r" \\",
+            )
+
+        this_latex_table = "\n".join(
+            [
+                latex_top,
+                *latex_table_content,
+                latex_bottom,
+            ]
+        )
+        all_latex_table_str.append(this_latex_table)
+
+    return "\n\n".join(all_latex_table_str)

--- a/pysr/export_latex.py
+++ b/pysr/export_latex.py
@@ -12,7 +12,7 @@ def set_precision_of_constants_in_string(s, precision=3):
 
 
 def generate_top_of_latex_table(columns=["Equation", "Complexity", "Loss"]):
-    margins = "".join([("c" if col == "Equation" else "l") for col in columns])
+    margins = "".join([("l" if col == "Equation" else "c") for col in columns])
     latex_table_pieces = [
         r"\begin{table}[h]",
         r"\begin{center}",

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -2000,7 +2000,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             return ret_outputs
         return ret_outputs[0]
 
-    def latex_table(self, indices=None, precision=3, include_score=False):
+    def _latex_table(self, indices=None, precision=3, include_score=False):
         """Create a LaTeX/booktabs table for all, or some, of the equations.
 
         Parameters

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1988,6 +1988,49 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             return ret_outputs
         return ret_outputs[0]
 
+    def latex_table(self, indices=None):
+        """Create a LaTeX/booktabs table for all, or some, of the equations.
+
+        Parameters
+        ----------
+        indices : list[int], default=None
+            If you wish to select a particular subset of equations from
+            `self.equations_`, give the row numbers here. By default,
+            all equations will be used.
+
+        Returns
+        -------
+        latex_table_string : str
+            A string that will render a table in LaTeX of the equations.
+        """
+        if indices is None:
+            indices = range(len(self.equations_))
+        latex_table_pieces = [
+            r"\begin{table}[h]",
+            r"\centering",
+            r"\caption{}",
+            r"\label{}",
+            r"\begin{tabular}{@{}lcc@{}}",
+            r"\toprule",
+            r"Equation & Complexity & Loss \\",
+            r"\midrule",
+        ]
+        for i in indices:
+            row_pieces = [
+                "$" + self.latex(i) + "$",
+                str(self.equations_.iloc[i]["complexity"]),
+                str(self.equations_.iloc[i]["loss"]),
+            ]
+            latex_table_pieces += [
+                " & ".join(row_pieces) + r" \\",
+            ]
+        latex_table_pieces += [
+            r"\bottomrule",
+            r"\end{tabular}",
+            r"\end{table}",
+        ]
+        return "\n".join(latex_table_pieces)
+
 
 def _denoise(X, y, Xresampled=None, random_state=None):
     """Denoise the dataset using a Gaussian process"""

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -2000,7 +2000,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             return ret_outputs
         return ret_outputs[0]
 
-    def _latex_table(self, indices=None, precision=3, include_score=False):
+    def latex_table(self, indices=None, precision=3, include_score=False):
         """Create a LaTeX/booktabs table for all, or some, of the equations.
 
         Parameters
@@ -2042,8 +2042,11 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         equations = self.equations_
 
         if isinstance(indices[0], int):
+            assert self.nout_ == 1, "For multiple outputs, pass a list of lists."
             indices = [indices]
             equations = [equations]
+
+        assert len(indices) == self.nout_
 
         latex_equations = [
             [to_latex(eq, prec=precision) for eq in equation_set["sympy_format"]]

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -2003,6 +2003,10 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         latex_table_string : str
             A string that will render a table in LaTeX of the equations.
         """
+        if self.nout_ > 1:
+            raise NotImplementedError(
+                "LaTeX tables are not implemented for multiple outputs."
+            )
         if indices is None:
             indices = range(len(self.equations_))
         latex_table_pieces = [

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -27,7 +27,7 @@ from .julia_helpers import (
     import_error_string,
 )
 from .export_numpy import CallableEquation
-from .export_latex import to_latex, generate_table
+from .export_latex import generate_single_table, generate_multiple_tables, to_latex
 from .deprecated import make_deprecated_kwargs_for_pysr_regressor
 
 
@@ -2024,26 +2024,18 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         """
         self.refresh()
 
-        # All indices:
-        if indices is None:
-            if self.nout_ > 1:
-                indices = [
-                    list(range(len(out_equations))) for out_equations in self.equations_
-                ]
-            else:
-                indices = list(range(len(self.equations_)))
+        if self.nout_ > 1:
+            if indices is not None:
+                assert isinstance(indices, list)
+                assert isinstance(indices[0], list)
+                assert isinstance(len(indices), self.nout_)
 
-        equations = self.equations_
+            generator_fnc = generate_multiple_tables
+        else:
+            generator_fnc = generate_single_table
 
-        if isinstance(indices[0], int):
-            assert self.nout_ == 1, "For multiple outputs, pass a list of lists."
-            indices = [indices]
-            equations = [equations]
-
-        assert len(indices) == self.nout_
-
-        return generate_table(
-            equations, indices=indices, precision=precision, columns=columns
+        return generator_fnc(
+            self.equations_, indices=indices, precision=precision, columns=columns
         )
 
 

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1721,7 +1721,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             return [eq["sympy_format"] for eq in best_equation]
         return best_equation["sympy_format"]
 
-    def latex(self, index=None):
+    def latex(self, index=None, precision=3):
         """
         Return latex representation of the equation(s) chosen by `model_selection`.
 
@@ -1733,6 +1733,9 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             the `model_selection` parameter. If there are multiple output
             features, then pass a list of indices with the order the same
             as the output feature.
+        precision : int, default=3
+            The number of significant figures shown in the LaTeX
+            representation.
 
         Returns
         -------
@@ -1742,8 +1745,16 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         self.refresh()
         sympy_representation = self.sympy(index=index)
         if self.nout_ > 1:
-            return [sympy.latex(s) for s in sympy_representation]
-        return sympy.latex(sympy_representation)
+            output = []
+            for s in sympy_representation:
+                raw_latex = sympy.latex(s)
+                reduced_latex = set_precision_of_constants_in_string(
+                    raw_latex, precision
+                )
+                output.append(reduced_latex)
+            return output
+        raw_latex = sympy.latex(sympy_representation)
+        return set_precision_of_constants_in_string(raw_latex, precision)
 
     def jax(self, index=None):
         """

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -2032,6 +2032,10 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
 
             generator_fnc = generate_multiple_tables
         else:
+            if indices is not None:
+                assert isinstance(indices, list)
+                assert isinstance(indices[0], int)
+
             generator_fnc = generate_single_table
 
         return generator_fnc(

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -2203,7 +2203,6 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         preamble_string = [
             r"\usepackage{breqn}",
             r"\usepackage{booktabs}",
-            r"\usepackage{tabularx}",
             "",
             "...",
             "",

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -2039,13 +2039,19 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             # Also convert these to reduced precision:
             # loss = self.equations_.iloc[i]["loss"]
             # score = self.equations_.iloc[i]["score"]
-            complexity = "{:d}".format(self.equations_.iloc[i]["complexity"])
-            loss = "{:.{p}g}".format(self.equations_.iloc[i]["loss"], p=precision)
-            score = "{:.{p}g}".format(self.equations_.iloc[i]["score"], p=precision)
+            complexity = str(self.equations_.iloc[i]["complexity"])
+            loss = to_latex(
+                sympy.Float(self.equations_.iloc[i]["loss"]), prec=precision
+            )
+            score = to_latex(
+                sympy.Float(self.equations_.iloc[i]["score"]), prec=precision
+            )
 
-            row_pieces = ["$" + equation + "$", complexity, loss]
+            row_pieces = [equation, complexity, loss]
             if include_score:
                 row_pieces.append(score)
+
+            row_pieces = ["$" + piece + "$" for piece in row_pieces]
 
             latex_table_content.append(
                 " & ".join(row_pieces) + r" \\",

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -27,7 +27,7 @@ from .julia_helpers import (
     import_error_string,
 )
 from .export_numpy import CallableEquation
-from .export_latex import to_latex, generate_table_environment
+from .export_latex import to_latex, generate_table
 from .deprecated import make_deprecated_kwargs_for_pysr_regressor
 
 
@@ -2033,8 +2033,6 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             else:
                 indices = list(range(len(self.equations_)))
 
-        latex_top, latex_bottom = generate_table_environment(columns)
-
         equations = self.equations_
 
         if isinstance(indices[0], int):
@@ -2044,57 +2042,9 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
 
         assert len(indices) == self.nout_
 
-        latex_equations = [
-            [to_latex(eq, prec=precision) for eq in equation_set["sympy_format"]]
-            for equation_set in equations
-        ]
-
-        all_latex_table_str = []
-
-        for output_feature, index_set in enumerate(indices):
-            latex_table_content = []
-            for i in index_set:
-                latex_equation = latex_equations[output_feature][i]
-                complexity = str(equations[output_feature].iloc[i]["complexity"])
-                loss = to_latex(
-                    sympy.Float(equations[output_feature].iloc[i]["loss"]),
-                    prec=precision,
-                )
-                score = to_latex(
-                    sympy.Float(equations[output_feature].iloc[i]["score"]),
-                    prec=precision,
-                )
-
-                row_pieces = []
-                for col in columns:
-                    if col == "equation":
-                        row_pieces.append(latex_equation)
-                    elif col == "complexity":
-                        row_pieces.append(complexity)
-                    elif col == "loss":
-                        row_pieces.append(loss)
-                    elif col == "score":
-                        row_pieces.append(score)
-                    else:
-                        raise ValueError(f"Unknown column: {col}")
-
-                row_pieces = ["$" + piece + "$" for piece in row_pieces]
-
-                latex_table_content.append(
-                    " & ".join(row_pieces) + r" \\",
-                )
-
-            all_latex_table_str.append(
-                "\n".join(
-                    [
-                        latex_top,
-                        *latex_table_content,
-                        latex_bottom,
-                    ]
-                )
-            )
-
-        return "\n\n".join(all_latex_table_str)
+        return generate_table(
+            equations, indices=indices, precision=precision, columns=columns
+        )
 
 
 def _denoise(X, y, Xresampled=None, random_state=None):

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -2004,7 +2004,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             return ret_outputs
         return ret_outputs[0]
 
-    def latex_table(self, indices=None, precision=3):
+    def latex_table(self, indices=None, precision=3, include_score=False):
         """Create a LaTeX/booktabs table for all, or some, of the equations.
 
         Parameters
@@ -2016,6 +2016,8 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         precision : int, default=3
             The number of significant figures shown in the LaTeX
             representations.
+        include_score : bool, default=False
+            Whether to include the score in the table.
 
         Returns
         -------
@@ -2028,17 +2030,33 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             )
         if indices is None:
             indices = range(len(self.equations_))
+
+        columns = ["Equation", "Complexity", "Loss"]
+        if include_score:
+            columns.append("Score")
+
+        latex_table_top = generate_top_of_latex_table(columns)
+
         latex_table_content = []
         for i in indices:
             equation = self.latex(i, precision=precision)
-            complexity = str(self.equations_.iloc[i]["complexity"])
-            loss = str(self.equations_.iloc[i]["loss"])
+            # Also convert these to reduced precision:
+            # loss = self.equations_.iloc[i]["loss"]
+            # score = self.equations_.iloc[i]["score"]
+            complexity = "{:d}".format(self.equations_.iloc[i]["complexity"])
+            loss = "{:.{p}g}".format(self.equations_.iloc[i]["loss"], p=precision)
+            score = "{:.{p}g}".format(self.equations_.iloc[i]["score"], p=precision)
+
             row_pieces = ["$" + equation + "$", complexity, loss]
+            if include_score:
+                row_pieces.append(score)
+
             latex_table_content.append(
                 " & ".join(row_pieces) + r" \\",
             )
-        latex_table_top = generate_top_of_latex_table()
+
         latex_table_bottom = generate_bottom_of_latex_table()
+
         latex_table_str = "\n".join(
             [
                 latex_table_top,

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -28,7 +28,7 @@ from .julia_helpers import (
 )
 from .export_numpy import CallableEquation
 from .export_latex import (
-    set_precision_of_constants_in_string,
+    to_latex,
     generate_top_of_latex_table,
     generate_bottom_of_latex_table,
 )
@@ -1752,14 +1752,10 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         if self.nout_ > 1:
             output = []
             for s in sympy_representation:
-                raw_latex = sympy.latex(s)
-                reduced_latex = set_precision_of_constants_in_string(
-                    raw_latex, precision
-                )
-                output.append(reduced_latex)
+                latex = to_latex(s, prec=precision)
+                output.append(latex)
             return output
-        raw_latex = sympy.latex(sympy_representation)
-        return set_precision_of_constants_in_string(raw_latex, precision)
+        return to_latex(sympy_representation, prec=precision)
 
     def jax(self, index=None):
         """

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -2000,7 +2000,12 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             return ret_outputs
         return ret_outputs[0]
 
-    def latex_table(self, indices=None, precision=3, include_score=False):
+    def latex_table(
+        self,
+        indices=None,
+        precision=3,
+        columns=["equation", "complexity", "loss", "score"],
+    ):
         """Create a LaTeX/booktabs table for all, or some, of the equations.
 
         Parameters
@@ -2013,8 +2018,8 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         precision : int, default=3
             The number of significant figures shown in the LaTeX
             representations.
-        include_score : bool, default=False
-            Whether to include the score in the table.
+        columns : list[str], default=["equation", "complexity", "loss", "score"]
+            Which columns to include in the table.
 
         Returns
         -------
@@ -2022,10 +2027,6 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             A string that will render a table in LaTeX of the equations.
         """
         self.refresh()
-
-        columns = ["Equation", "Complexity", "Loss"]
-        if include_score:
-            columns.append("Score")
 
         # All indices:
         if indices is None:
@@ -2069,9 +2070,18 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                     prec=precision,
                 )
 
-                row_pieces = [latex_equation, complexity, loss]
-                if include_score:
-                    row_pieces.append(score)
+                row_pieces = []
+                for col in columns:
+                    if col == "equation":
+                        row_pieces.append(latex_equation)
+                    elif col == "complexity":
+                        row_pieces.append(complexity)
+                    elif col == "loss":
+                        row_pieces.append(loss)
+                    elif col == "score":
+                        row_pieces.append(score)
+                    else:
+                        raise ValueError(f"Unknown column: {col}")
 
                 row_pieces = ["$" + piece + "$" for piece in row_pieces]
 

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -2197,9 +2197,18 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
 
             generator_fnc = generate_single_table
 
-        return generator_fnc(
+        table_string = generator_fnc(
             self.equations_, indices=indices, precision=precision, columns=columns
         )
+        preamble_string = [
+            r"\usepackage{breqn}",
+            r"\usepackage{booktabs}",
+            r"\usepackage{tabularx}",
+            "",
+            "...",
+            "",
+        ]
+        return "\n".join(preamble_string + [table_string])
 
 
 def idx_model_selection(equations: pd.DataFrame, model_selection: str) -> int:

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -27,11 +27,7 @@ from .julia_helpers import (
     import_error_string,
 )
 from .export_numpy import CallableEquation
-from .export_latex import (
-    to_latex,
-    generate_top_of_latex_table,
-    generate_bottom_of_latex_table,
-)
+from .export_latex import to_latex, generate_table_environment
 from .deprecated import make_deprecated_kwargs_for_pysr_regressor
 
 
@@ -2037,8 +2033,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             else:
                 indices = list(range(len(self.equations_)))
 
-        latex_table_top = generate_top_of_latex_table(columns)
-        latex_table_bottom = generate_bottom_of_latex_table()
+        latex_top, latex_bottom = generate_table_environment(columns)
 
         equations = self.equations_
 
@@ -2092,9 +2087,9 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             all_latex_table_str.append(
                 "\n".join(
                     [
-                        latex_table_top,
+                        latex_top,
                         *latex_table_content,
-                        latex_table_bottom,
+                        latex_bottom,
                     ]
                 )
             )

--- a/test/test.py
+++ b/test/test.py
@@ -524,7 +524,7 @@ class TestLaTeXTable(unittest.TestCase):
             true_latex_table_str = r"""
                 \begin{table}[h]
                 \begin{center}
-                \begin{tabular}{@{}lccc@{}}
+                \begin{tabular}{@{}cccc@{}}
                 \toprule
                 Equation & Complexity & Loss & Score \\
                 \midrule"""
@@ -532,7 +532,7 @@ class TestLaTeXTable(unittest.TestCase):
             true_latex_table_str = r"""
                 \begin{table}[h]
                 \begin{center}
-                \begin{tabular}{@{}lcc@{}}
+                \begin{tabular}{@{}ccc@{}}
                 \toprule
                 Equation & Complexity & Loss \\
                 \midrule"""
@@ -669,7 +669,7 @@ class TestLaTeXTable(unittest.TestCase):
         middle_part = r"""
         $x_{0}$ & $1$ & $1.05$ & $0.0$ \\
         $\cos{\left(x_{0} \right)}$ & $2$ & $0.0232$ & $3.82$ \\
-        \vbox{ \vspace{-1em} \begin{flushleft} $\displaystyle x_{0}^{5} + x_{0}^{3} + 3.20 x_{0} + x_{1}^{3} - 1.20 x_{1} - 5.20 \sin{\left(2.60 x_{0} - 0.326 \sin{\left(x_{2} \right)} \right)} - \cos{\left(x_{0} x_{1} \right)} + \cos{\left(x_{0}^{3} + 3.20 x_{0} + x_{1}^{3} - 1.20 x_{1} + \cos{\left(x_{0} x_{1} \right)} \right)} $ \end{flushleft} \vspace{-1em} } & $30$ & $1.12 \cdot 10^{-15}$ & $1.09$ \\
+        \begin{minipage}{0.8\linewidth} \vspace{-1em} \begin{dmath*} x_{0}^{5} + x_{0}^{3} + 3.20 x_{0} + x_{1}^{3} - 1.20 x_{1} - 5.20 \sin{\left(2.60 x_{0} - 0.326 \sin{\left(x_{2} \right)} \right)} - \cos{\left(x_{0} x_{1} \right)} + \cos{\left(x_{0}^{3} + 3.20 x_{0} + x_{1}^{3} - 1.20 x_{1} + \cos{\left(x_{0} x_{1} \right)} \right)} \end{dmath*} \end{minipage} & $30$ & $1.12 \cdot 10^{-15}$ & $1.09$ \\
         """
         true_latex_table_str = self.create_true_latex(middle_part, include_score=True)
         self.assertEqual(latex_table_str, true_latex_table_str)

--- a/test/test.py
+++ b/test/test.py
@@ -540,9 +540,9 @@ class TestLaTeXTable(unittest.TestCase):
         # Regular table:
         latex_table_str = model.latex_table()
         middle_part = r"""
-            $x_{0}$ & 1 & 1.05 \\
-            $\cos{\left(x_{0} \right)}$ & 2 & 0.0232 \\
-            $x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & 8 & 1.12e-15 \\
+            $x_{0}$ & $1$ & $1.05$ \\
+            $\cos{\left(x_{0} \right)}$ & $2$ & $0.0232$ \\
+            $x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & $8$ & $1.12 \cdot 10^{-15}$ \\
         """
         true_latex_table_str = self.create_true_latex(middle_part)
         self.assertEqual(latex_table_str, true_latex_table_str)
@@ -550,9 +550,9 @@ class TestLaTeXTable(unittest.TestCase):
         # Different precision:
         latex_table_str = model.latex_table(precision=5)
         middle_part = r"""
-            $x_{0}$ & 1 & 1.052 \\
-            $\cos{\left(x_{0} \right)}$ & 2 & 0.02315 \\
-            $x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & 8 & 1.1235e-15 \\
+            $x_{0}$ & $1$ & $1.052$ \\
+            $\cos{\left(x_{0} \right)}$ & $2$ & $0.02315$ \\
+            $x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & $8$ & $1.1235 \cdot 10^{-15}$ \\
         """
         true_latex_table_str = self.create_true_latex(middle_part)
         self.assertEqual(latex_table_str, self.create_true_latex(middle_part))
@@ -560,9 +560,9 @@ class TestLaTeXTable(unittest.TestCase):
         # Including score:
         latex_table_str = model.latex_table(include_score=True)
         middle_part = r"""
-            $x_{0}$ & 1 & 1.05 & 0 \\
-            $\cos{\left(x_{0} \right)}$ & 2 & 0.0232 & 3.82 \\
-            $x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & 8 & 1.12e-15 & 5.11 \\
+            $x_{0}$ & $1$ & $1.05$ & $0.0$ \\
+            $\cos{\left(x_{0} \right)}$ & $2$ & $0.0232$ & $3.82$ \\
+            $x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & $8$ & $1.12 \cdot 10^{-15}$ & $5.11$ \\
         """
         true_latex_table_str = self.create_true_latex(middle_part, include_score=True)
         self.assertEqual(latex_table_str, true_latex_table_str)
@@ -570,7 +570,7 @@ class TestLaTeXTable(unittest.TestCase):
         # Only last equation:
         latex_table_str = model.latex_table(indices=[2])
         middle_part = r"""
-            $x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & 8 & 1.12e-15 \\
+            $x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & $8$ & $1.12 \cdot 10^{-15}$ \\
         """
         true_latex_table_str = self.create_true_latex(middle_part)
         self.assertEqual(latex_table_str, true_latex_table_str)

--- a/test/test.py
+++ b/test/test.py
@@ -498,6 +498,16 @@ class TestMiscellaneous(unittest.TestCase):
 
 
 class TestLaTeXTable(unittest.TestCase):
+    def setUp(self):
+        equations = pd.DataFrame(
+            dict(
+                equation=["x0", "cos(x0)", "x0 + x1 - cos(x1 * x0)"],
+                loss=[1.052, 0.02315, 1.12347e-15],
+                complexity=[1, 2, 8],
+            )
+        )
+        self.model = manually_create_model(equations)
+
     def create_true_latex(self, middle_part, include_score=False):
         if include_score:
             true_latex_table_str = r"""
@@ -528,17 +538,9 @@ class TestLaTeXTable(unittest.TestCase):
         return true_latex_table_str.strip()
 
     def test_simple_table(self):
-        equations = pd.DataFrame(
-            dict(
-                equation=["x0", "cos(x0)", "x0 + x1 - cos(x1 * x0)"],
-                loss=[1.052, 0.02315, 1.12347e-15],
-                complexity=[1, 2, 8],
-            )
+        latex_table_str = self.model.latex_table(
+            columns=["equation", "complexity", "loss"]
         )
-        model = manually_create_model(equations)
-
-        # Regular table:
-        latex_table_str = model.latex_table(columns=["equation", "complexity", "loss"])
         middle_part = r"""
             $x_{0}$ & $1$ & $1.05$ \\
             $\cos{\left(x_{0} \right)}$ & $2$ & $0.0232$ \\
@@ -547,8 +549,8 @@ class TestLaTeXTable(unittest.TestCase):
         true_latex_table_str = self.create_true_latex(middle_part)
         self.assertEqual(latex_table_str, true_latex_table_str)
 
-        # Different precision:
-        latex_table_str = model.latex_table(
+    def test_other_precision(self):
+        latex_table_str = self.model.latex_table(
             precision=5, columns=["equation", "complexity", "loss"]
         )
         middle_part = r"""
@@ -557,10 +559,10 @@ class TestLaTeXTable(unittest.TestCase):
             $x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & $8$ & $1.1235 \cdot 10^{-15}$ \\
         """
         true_latex_table_str = self.create_true_latex(middle_part)
-        self.assertEqual(latex_table_str, self.create_true_latex(middle_part))
+        self.assertEqual(latex_table_str, true_latex_table_str)
 
-        # Including score:
-        latex_table_str = model.latex_table()
+    def test_include_score(self):
+        latex_table_str = self.model.latex_table()
         middle_part = r"""
             $x_{0}$ & $1$ & $1.05$ & $0.0$ \\
             $\cos{\left(x_{0} \right)}$ & $2$ & $0.0232$ & $3.82$ \\
@@ -569,8 +571,8 @@ class TestLaTeXTable(unittest.TestCase):
         true_latex_table_str = self.create_true_latex(middle_part, include_score=True)
         self.assertEqual(latex_table_str, true_latex_table_str)
 
-        # Only last equation:
-        latex_table_str = model.latex_table(
+    def test_last_equation(self):
+        latex_table_str = self.model.latex_table(
             indices=[2], columns=["equation", "complexity", "loss"]
         )
         middle_part = r"""

--- a/test/test.py
+++ b/test/test.py
@@ -538,7 +538,7 @@ class TestLaTeXTable(unittest.TestCase):
         model = manually_create_model(equations)
 
         # Regular table:
-        latex_table_str = model.latex_table()
+        latex_table_str = model._latex_table()
         middle_part = r"""
             $x_{0}$ & $1$ & $1.05$ \\
             $\cos{\left(x_{0} \right)}$ & $2$ & $0.0232$ \\
@@ -548,7 +548,7 @@ class TestLaTeXTable(unittest.TestCase):
         self.assertEqual(latex_table_str, true_latex_table_str)
 
         # Different precision:
-        latex_table_str = model.latex_table(precision=5)
+        latex_table_str = model._latex_table(precision=5)
         middle_part = r"""
             $x_{0}$ & $1$ & $1.0520$ \\
             $\cos{\left(x_{0} \right)}$ & $2$ & $0.023150$ \\
@@ -558,7 +558,7 @@ class TestLaTeXTable(unittest.TestCase):
         self.assertEqual(latex_table_str, self.create_true_latex(middle_part))
 
         # Including score:
-        latex_table_str = model.latex_table(include_score=True)
+        latex_table_str = model._latex_table(include_score=True)
         middle_part = r"""
             $x_{0}$ & $1$ & $1.05$ & $0.0$ \\
             $\cos{\left(x_{0} \right)}$ & $2$ & $0.0232$ & $3.82$ \\
@@ -568,7 +568,7 @@ class TestLaTeXTable(unittest.TestCase):
         self.assertEqual(latex_table_str, true_latex_table_str)
 
         # Only last equation:
-        latex_table_str = model.latex_table(indices=[2])
+        latex_table_str = model._latex_table(indices=[2])
         middle_part = r"""
             $x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & $8$ & $1.12 \cdot 10^{-15}$ \\
         """

--- a/test/test.py
+++ b/test/test.py
@@ -550,8 +550,8 @@ class TestLaTeXTable(unittest.TestCase):
         # Different precision:
         latex_table_str = model.latex_table(precision=5)
         middle_part = r"""
-            $x_{0}$ & $1$ & $1.052$ \\
-            $\cos{\left(x_{0} \right)}$ & $2$ & $0.02315$ \\
+            $x_{0}$ & $1$ & $1.0520$ \\
+            $\cos{\left(x_{0} \right)}$ & $2$ & $0.023150$ \\
             $x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & $8$ & $1.1235 \cdot 10^{-15}$ \\
         """
         true_latex_table_str = self.create_true_latex(middle_part)
@@ -580,7 +580,7 @@ class TestLaTeXTable(unittest.TestCase):
         expr = sympy.Float(4583.4485748, dps=50)
         self.assertEqual(to_latex(expr, prec=6), r"4583.45")
         self.assertEqual(to_latex(expr, prec=5), r"4583.4")
-        self.assertEqual(to_latex(expr, prec=4), r"4583.0")
+        self.assertEqual(to_latex(expr, prec=4), r"4583.")
         self.assertEqual(to_latex(expr, prec=3), r"4.58 \cdot 10^{3}")
         self.assertEqual(to_latex(expr, prec=2), r"4.6 \cdot 10^{3}")
 

--- a/test/test.py
+++ b/test/test.py
@@ -608,6 +608,18 @@ class TestMiscellaneous(unittest.TestCase):
         self.assertEqual(len(exception_messages), 0)
 
 
+TRUE_PREAMBLE = "\n".join(
+    [
+        r"\usepackage{breqn}",
+        r"\usepackage{booktabs}",
+        r"\usepackage{tabularx}",
+        "",
+        "...",
+        "",
+    ]
+)
+
+
 class TestLaTeXTable(unittest.TestCase):
     def setUp(self):
         equations = pd.DataFrame(
@@ -618,6 +630,7 @@ class TestLaTeXTable(unittest.TestCase):
             )
         )
         self.model = manually_create_model(equations)
+        self.maxDiff = None
 
     def create_true_latex(self, middle_part, include_score=False):
         if include_score:
@@ -657,7 +670,9 @@ class TestLaTeXTable(unittest.TestCase):
             $y = \cos{\left(x_{0} \right)}$ & $2$ & $0.0232$ \\
             $y = x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & $8$ & $1.12 \cdot 10^{-15}$ \\
         """
-        true_latex_table_str = self.create_true_latex(middle_part)
+        true_latex_table_str = (
+            TRUE_PREAMBLE + "\n" + self.create_true_latex(middle_part)
+        )
         self.assertEqual(latex_table_str, true_latex_table_str)
 
     def test_other_precision(self):
@@ -669,7 +684,9 @@ class TestLaTeXTable(unittest.TestCase):
             $y = \cos{\left(x_{0} \right)}$ & $2$ & $0.023150$ \\
             $y = x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & $8$ & $1.1235 \cdot 10^{-15}$ \\
         """
-        true_latex_table_str = self.create_true_latex(middle_part)
+        true_latex_table_str = (
+            TRUE_PREAMBLE + "\n" + self.create_true_latex(middle_part)
+        )
         self.assertEqual(latex_table_str, true_latex_table_str)
 
     def test_include_score(self):
@@ -679,7 +696,11 @@ class TestLaTeXTable(unittest.TestCase):
             $y = \cos{\left(x_{0} \right)}$ & $2$ & $0.0232$ & $3.82$ \\
             $y = x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & $8$ & $1.12 \cdot 10^{-15}$ & $5.11$ \\
         """
-        true_latex_table_str = self.create_true_latex(middle_part, include_score=True)
+        true_latex_table_str = (
+            TRUE_PREAMBLE
+            + "\n"
+            + self.create_true_latex(middle_part, include_score=True)
+        )
         self.assertEqual(latex_table_str, true_latex_table_str)
 
     def test_last_equation(self):
@@ -689,7 +710,9 @@ class TestLaTeXTable(unittest.TestCase):
         middle_part = r"""
             $y = x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & $8$ & $1.12 \cdot 10^{-15}$ \\
         """
-        true_latex_table_str = self.create_true_latex(middle_part)
+        true_latex_table_str = (
+            TRUE_PREAMBLE + "\n" + self.create_true_latex(middle_part)
+        )
         self.assertEqual(latex_table_str, true_latex_table_str)
 
     def test_multi_output(self):
@@ -723,6 +746,7 @@ class TestLaTeXTable(unittest.TestCase):
             self.create_true_latex(part, include_score=True)
             for part in [middle_part_1, middle_part_2]
         )
+        true_latex_table_str = TRUE_PREAMBLE + "\n" + true_latex_table_str
         latex_table_str = model.latex_table()
 
         self.assertEqual(latex_table_str, true_latex_table_str)
@@ -771,5 +795,9 @@ class TestLaTeXTable(unittest.TestCase):
         $y = \cos{\left(x_{0} \right)}$ & $2$ & $0.0232$ & $3.82$ \\
         \begin{minipage}{0.8\linewidth} \vspace{-1em} \begin{dmath*} y = x_{0}^{5} + x_{0}^{3} + 3.20 x_{0} + x_{1}^{3} - 1.20 x_{1} - 5.20 \sin{\left(2.60 x_{0} - 0.326 \sin{\left(x_{2} \right)} \right)} - \cos{\left(x_{0} x_{1} \right)} + \cos{\left(x_{0}^{3} + 3.20 x_{0} + x_{1}^{3} - 1.20 x_{1} + \cos{\left(x_{0} x_{1} \right)} \right)} \end{dmath*} \end{minipage} & $30$ & $1.12 \cdot 10^{-15}$ & $1.09$ \\
         """
-        true_latex_table_str = self.create_true_latex(middle_part, include_score=True)
+        true_latex_table_str = (
+            TRUE_PREAMBLE
+            + "\n"
+            + self.create_true_latex(middle_part, include_score=True)
+        )
         self.assertEqual(latex_table_str, true_latex_table_str)

--- a/test/test.py
+++ b/test/test.py
@@ -538,7 +538,7 @@ class TestLaTeXTable(unittest.TestCase):
         model = manually_create_model(equations)
 
         # Regular table:
-        latex_table_str = model._latex_table()
+        latex_table_str = model.latex_table()
         middle_part = r"""
             $x_{0}$ & $1$ & $1.05$ \\
             $\cos{\left(x_{0} \right)}$ & $2$ & $0.0232$ \\
@@ -548,7 +548,7 @@ class TestLaTeXTable(unittest.TestCase):
         self.assertEqual(latex_table_str, true_latex_table_str)
 
         # Different precision:
-        latex_table_str = model._latex_table(precision=5)
+        latex_table_str = model.latex_table(precision=5)
         middle_part = r"""
             $x_{0}$ & $1$ & $1.0520$ \\
             $\cos{\left(x_{0} \right)}$ & $2$ & $0.023150$ \\
@@ -558,7 +558,7 @@ class TestLaTeXTable(unittest.TestCase):
         self.assertEqual(latex_table_str, self.create_true_latex(middle_part))
 
         # Including score:
-        latex_table_str = model._latex_table(include_score=True)
+        latex_table_str = model.latex_table(include_score=True)
         middle_part = r"""
             $x_{0}$ & $1$ & $1.05$ & $0.0$ \\
             $\cos{\left(x_{0} \right)}$ & $2$ & $0.0232$ & $3.82$ \\
@@ -568,7 +568,7 @@ class TestLaTeXTable(unittest.TestCase):
         self.assertEqual(latex_table_str, true_latex_table_str)
 
         # Only last equation:
-        latex_table_str = model._latex_table(indices=[2])
+        latex_table_str = model.latex_table(indices=[2])
         middle_part = r"""
             $x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & $8$ & $1.12 \cdot 10^{-15}$ \\
         """

--- a/test/test.py
+++ b/test/test.py
@@ -502,7 +502,7 @@ class TestLaTeXTable(unittest.TestCase):
             true_latex_table_str = r"""
                 \begin{table}[h]
                 \begin{center}
-                \begin{tabular}{@{}clll@{}}
+                \begin{tabular}{@{}lccc@{}}
                 \toprule
                 Equation & Complexity & Loss & Score \\
                 \midrule"""
@@ -510,7 +510,7 @@ class TestLaTeXTable(unittest.TestCase):
             true_latex_table_str = r"""
                 \begin{table}[h]
                 \begin{center}
-                \begin{tabular}{@{}cll@{}}
+                \begin{tabular}{@{}lcc@{}}
                 \toprule
                 Equation & Complexity & Loss \\
                 \midrule"""

--- a/test/test.py
+++ b/test/test.py
@@ -538,7 +538,7 @@ class TestLaTeXTable(unittest.TestCase):
         model = manually_create_model(equations)
 
         # Regular table:
-        latex_table_str = model.latex_table()
+        latex_table_str = model.latex_table(columns=["equation", "complexity", "loss"])
         middle_part = r"""
             $x_{0}$ & $1$ & $1.05$ \\
             $\cos{\left(x_{0} \right)}$ & $2$ & $0.0232$ \\
@@ -548,7 +548,9 @@ class TestLaTeXTable(unittest.TestCase):
         self.assertEqual(latex_table_str, true_latex_table_str)
 
         # Different precision:
-        latex_table_str = model.latex_table(precision=5)
+        latex_table_str = model.latex_table(
+            precision=5, columns=["equation", "complexity", "loss"]
+        )
         middle_part = r"""
             $x_{0}$ & $1$ & $1.0520$ \\
             $\cos{\left(x_{0} \right)}$ & $2$ & $0.023150$ \\
@@ -558,7 +560,7 @@ class TestLaTeXTable(unittest.TestCase):
         self.assertEqual(latex_table_str, self.create_true_latex(middle_part))
 
         # Including score:
-        latex_table_str = model.latex_table(include_score=True)
+        latex_table_str = model.latex_table()
         middle_part = r"""
             $x_{0}$ & $1$ & $1.05$ & $0.0$ \\
             $\cos{\left(x_{0} \right)}$ & $2$ & $0.0232$ & $3.82$ \\
@@ -568,7 +570,9 @@ class TestLaTeXTable(unittest.TestCase):
         self.assertEqual(latex_table_str, true_latex_table_str)
 
         # Only last equation:
-        latex_table_str = model.latex_table(indices=[2])
+        latex_table_str = model.latex_table(
+            indices=[2], columns=["equation", "complexity", "loss"]
+        )
         middle_part = r"""
             $x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & $8$ & $1.12 \cdot 10^{-15}$ \\
         """

--- a/test/test.py
+++ b/test/test.py
@@ -612,7 +612,6 @@ TRUE_PREAMBLE = "\n".join(
     [
         r"\usepackage{breqn}",
         r"\usepackage{booktabs}",
-        r"\usepackage{tabularx}",
         "",
         "...",
         "",

--- a/test/test.py
+++ b/test/test.py
@@ -6,6 +6,7 @@ import numpy as np
 from sklearn import model_selection
 from pysr import PySRRegressor
 from pysr.sr import run_feature_selection, _handle_feature_selection
+from pysr.export_latex import to_latex
 from sklearn.utils.estimator_checks import check_estimator
 import sympy
 import pandas as pd
@@ -573,3 +574,25 @@ class TestLaTeXTable(unittest.TestCase):
         """
         true_latex_table_str = self.create_true_latex(middle_part)
         self.assertEqual(latex_table_str, true_latex_table_str)
+
+    def test_latex_float_precision(self):
+        """Test that we can print latex expressions with custom precision"""
+        expr = sympy.Float(4583.4485748, dps=50)
+        self.assertEqual(to_latex(expr, prec=6), r"4583.45")
+        self.assertEqual(to_latex(expr, prec=5), r"4583.4")
+        self.assertEqual(to_latex(expr, prec=4), r"4583.0")
+        self.assertEqual(to_latex(expr, prec=3), r"4.58 \cdot 10^{3}")
+        self.assertEqual(to_latex(expr, prec=2), r"4.6 \cdot 10^{3}")
+
+        # Multiple numbers:
+        x = sympy.Symbol("x")
+        expr = x * 3232.324857384 - 1.4857485e-10
+        self.assertEqual(
+            to_latex(expr, prec=2), "3.2 \cdot 10^{3} x - 1.5 \cdot 10^{-10}"
+        )
+        self.assertEqual(
+            to_latex(expr, prec=3), "3.23 \cdot 10^{3} x - 1.49 \cdot 10^{-10}"
+        )
+        self.assertEqual(
+            to_latex(expr, prec=8), "3232.3249 x - 1.4857485 \cdot 10^{-10}"
+        )

--- a/test/test.py
+++ b/test/test.py
@@ -553,9 +553,9 @@ class TestLaTeXTable(unittest.TestCase):
             columns=["equation", "complexity", "loss"]
         )
         middle_part = r"""
-            $x_{0}$ & $1$ & $1.05$ \\
-            $\cos{\left(x_{0} \right)}$ & $2$ & $0.0232$ \\
-            $x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & $8$ & $1.12 \cdot 10^{-15}$ \\
+            $y = x_{0}$ & $1$ & $1.05$ \\
+            $y = \cos{\left(x_{0} \right)}$ & $2$ & $0.0232$ \\
+            $y = x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & $8$ & $1.12 \cdot 10^{-15}$ \\
         """
         true_latex_table_str = self.create_true_latex(middle_part)
         self.assertEqual(latex_table_str, true_latex_table_str)
@@ -565,9 +565,9 @@ class TestLaTeXTable(unittest.TestCase):
             precision=5, columns=["equation", "complexity", "loss"]
         )
         middle_part = r"""
-            $x_{0}$ & $1$ & $1.0520$ \\
-            $\cos{\left(x_{0} \right)}$ & $2$ & $0.023150$ \\
-            $x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & $8$ & $1.1235 \cdot 10^{-15}$ \\
+            $y = x_{0}$ & $1$ & $1.0520$ \\
+            $y = \cos{\left(x_{0} \right)}$ & $2$ & $0.023150$ \\
+            $y = x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & $8$ & $1.1235 \cdot 10^{-15}$ \\
         """
         true_latex_table_str = self.create_true_latex(middle_part)
         self.assertEqual(latex_table_str, true_latex_table_str)
@@ -575,9 +575,9 @@ class TestLaTeXTable(unittest.TestCase):
     def test_include_score(self):
         latex_table_str = self.model.latex_table()
         middle_part = r"""
-            $x_{0}$ & $1$ & $1.05$ & $0.0$ \\
-            $\cos{\left(x_{0} \right)}$ & $2$ & $0.0232$ & $3.82$ \\
-            $x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & $8$ & $1.12 \cdot 10^{-15}$ & $5.11$ \\
+            $y = x_{0}$ & $1$ & $1.05$ & $0.0$ \\
+            $y = \cos{\left(x_{0} \right)}$ & $2$ & $0.0232$ & $3.82$ \\
+            $y = x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & $8$ & $1.12 \cdot 10^{-15}$ & $5.11$ \\
         """
         true_latex_table_str = self.create_true_latex(middle_part, include_score=True)
         self.assertEqual(latex_table_str, true_latex_table_str)
@@ -587,7 +587,7 @@ class TestLaTeXTable(unittest.TestCase):
             indices=[2], columns=["equation", "complexity", "loss"]
         )
         middle_part = r"""
-            $x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & $8$ & $1.12 \cdot 10^{-15}$ \\
+            $y = x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & $8$ & $1.12 \cdot 10^{-15}$ \\
         """
         true_latex_table_str = self.create_true_latex(middle_part)
         self.assertEqual(latex_table_str, true_latex_table_str)
@@ -610,14 +610,14 @@ class TestLaTeXTable(unittest.TestCase):
         equations = [equations1, equations2]
         model = manually_create_model(equations)
         middle_part_1 = r"""
-            $x_{0}$ & $1$ & $1.05$ & $0.0$ \\
-            $\cos{\left(x_{0} \right)}$ & $2$ & $0.0232$ & $3.82$ \\
-            $x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & $8$ & $1.12 \cdot 10^{-15}$ & $5.11$ \\
+            $y_{0} = x_{0}$ & $1$ & $1.05$ & $0.0$ \\
+            $y_{0} = \cos{\left(x_{0} \right)}$ & $2$ & $0.0232$ & $3.82$ \\
+            $y_{0} = x_{0} + x_{1} - \cos{\left(x_{0} x_{1} \right)}$ & $8$ & $1.12 \cdot 10^{-15}$ & $5.11$ \\
         """
         middle_part_2 = r"""
-            $x_{1}$ & $1$ & $1.32$ & $0.0$ \\
-            $\cos{\left(x_{1} \right)}$ & $2$ & $0.0520$ & $3.23$ \\
-            $x_{0}^{2} x_{1}$ & $5$ & $2.00 \cdot 10^{-15}$ & $10.3$ \\
+            $y_{1} = x_{1}$ & $1$ & $1.32$ & $0.0$ \\
+            $y_{1} = \cos{\left(x_{1} \right)}$ & $2$ & $0.0520$ & $3.23$ \\
+            $y_{1} = x_{0}^{2} x_{1}$ & $5$ & $2.00 \cdot 10^{-15}$ & $10.3$ \\
         """
         true_latex_table_str = "\n\n".join(
             self.create_true_latex(part, include_score=True)
@@ -667,9 +667,9 @@ class TestLaTeXTable(unittest.TestCase):
         model = manually_create_model(equations)
         latex_table_str = model.latex_table()
         middle_part = r"""
-        $x_{0}$ & $1$ & $1.05$ & $0.0$ \\
-        $\cos{\left(x_{0} \right)}$ & $2$ & $0.0232$ & $3.82$ \\
-        \begin{minipage}{0.8\linewidth} \vspace{-1em} \begin{dmath*} x_{0}^{5} + x_{0}^{3} + 3.20 x_{0} + x_{1}^{3} - 1.20 x_{1} - 5.20 \sin{\left(2.60 x_{0} - 0.326 \sin{\left(x_{2} \right)} \right)} - \cos{\left(x_{0} x_{1} \right)} + \cos{\left(x_{0}^{3} + 3.20 x_{0} + x_{1}^{3} - 1.20 x_{1} + \cos{\left(x_{0} x_{1} \right)} \right)} \end{dmath*} \end{minipage} & $30$ & $1.12 \cdot 10^{-15}$ & $1.09$ \\
+        $y = x_{0}$ & $1$ & $1.05$ & $0.0$ \\
+        $y = \cos{\left(x_{0} \right)}$ & $2$ & $0.0232$ & $3.82$ \\
+        \begin{minipage}{0.8\linewidth} \vspace{-1em} \begin{dmath*} y = x_{0}^{5} + x_{0}^{3} + 3.20 x_{0} + x_{1}^{3} - 1.20 x_{1} - 5.20 \sin{\left(2.60 x_{0} - 0.326 \sin{\left(x_{2} \right)} \right)} - \cos{\left(x_{0} x_{1} \right)} + \cos{\left(x_{0}^{3} + 3.20 x_{0} + x_{1}^{3} - 1.20 x_{1} + \cos{\left(x_{0} x_{1} \right)} \right)} \end{dmath*} \end{minipage} & $30$ & $1.12 \cdot 10^{-15}$ & $1.09$ \\
         """
         true_latex_table_str = self.create_true_latex(middle_part, include_score=True)
         self.assertEqual(latex_table_str, true_latex_table_str)


### PR DESCRIPTION
This generates a booktabs-style LaTeX table for a subset of equations. Here is an example:

```python
import numpy as np
from pysr import PySRRegressor

X = 2 * np.random.randn(100, 5)
y = 2.5382 * np.cos(X[:, 3]) + X[:, 0] ** 2 - 0.5

model = PySRRegressor(
    niterations=80,
    binary_operators=["+", "*"],
    unary_operators=["cos"],
    model_selection="best",
    loss="loss(x, y) = (x - y)^2",  # Custom loss function (julia syntax)
    maxsize=11,
)

model.fit(X, y)

print(model.latex_table(precision=3, include_score=True))
```

The output of this is:
```latex
\begin{table}[h]
\begin{center}
\begin{tabular}{@{}lccc@{}}
\toprule
Equation & Complexity & Loss & Score \\
\midrule
$3.9$ & 1 & 38.9 & 0 \\
$x_{0}^{2}$ & 3 & 3.16 & 1.26 \\
$x_{0}^{2} - 0.257$ & 5 & 3.09 & 0.0105 \\
$x_{0}^{2} + \cos{\left(x_{3} \right)}$ & 6 & 1.26 & 0.898 \\
$x_{0}^{2} + 2.44 \cos{\left(x_{3} \right)}$ & 8 & 0.245 & 0.818 \\
$x_{0}^{2} + 2.54 \cos{\left(x_{3} \right)} - 0.5$ & 10 & 2.28e-13 & 13.9 \\
\bottomrule
\end{tabular}
\end{center}
\end{table}
```
which renders as:
![image](https://user-images.githubusercontent.com/7593028/176985637-7ce05939-9722-4271-9460-15c35979c04a.png)

Leaving `include_score` set to `False` will leave out the Score column. Precision can be adjusted to have more or less precise constants.

One can render only a subset of equations by using `latex_table([1, 4])` which only includes the 1st and 4th equation in `model.equations_`.

---

Edit: it now renders the `e-13` as `\cdot 10^{-13}`