### PR TITLE
[Feature] Easy loading from equation file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.csv
 *.csv.out*
 *.bkup
+*.pkl
 performance*txt
 *.out
 trials*

--- a/README.md
+++ b/README.md
@@ -162,7 +162,15 @@ This arrow in the `pick` column indicates which equation is currently selected b
 SymPy format (`sympy_format` - which you can also get with `model.sympy()`), and even JAX and PyTorch format 
 (both of which are differentiable - which you can get with `model.jax()` and `model.pytorch()`).
 
-Note that `PySRRegressor` stores the state of the last search, and will restart from where you left off the next time you call `.fit()`. This will cause problems if significant changes are made to the search parameters (like changing the operators). You can run `model.reset()` to reset the state.
+Note that `PySRRegressor` stores the state of the last search, and will restart from where you left off the next time you call `.fit()`, assuming you have set `warm_start=True`.
+This will cause problems if significant changes are made to the search parameters (like changing the operators). You can run `model.reset()` to reset the state.
+
+You will notice that PySR will save two files: `hall_of_fame...csv` and `hall_of_fame...pkl`.
+The csv file is a list of equations and their losses, and the pkl file is a saved state of the model.
+You may load the model from the `pkl` file with:
+```python
+model = PySRRegressor.from_file("hall_of_fame.2022-08-10_100832.281.pkl")
+``` 
 
 There are several other useful features such as denoising (e.g., `denoising=True`),
 feature selection (e.g., `select_k_features=3`).

--- a/pysr/__init__.py
+++ b/pysr/__init__.py
@@ -6,7 +6,6 @@ from .sr import (
     best_tex,
     best_callable,
     best_row,
-    load,
 )
 from .julia_helpers import install
 from .feynman_problems import Problem, FeynmanProblem

--- a/pysr/__init__.py
+++ b/pysr/__init__.py
@@ -6,6 +6,7 @@ from .sr import (
     best_tex,
     best_callable,
     best_row,
+    load,
 )
 from .julia_helpers import install
 from .feynman_problems import Problem, FeynmanProblem

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -2034,3 +2034,77 @@ def run_feature_selection(X, y, select_k_features, random_state=None):
         clf, threshold=-np.inf, max_features=select_k_features, prefit=True
     )
     return selector.get_support(indices=True)
+
+
+def load(
+    equation_file,
+    *,
+    binary_operators,
+    unary_operators,
+    n_features_in,
+    feature_names_in=None,
+    selection_mask=None,
+    nout=1,
+    **pysr_kwargs,
+):
+    """
+    Create a model from equations stored as a csv file
+
+    Parameters
+    ----------
+    equation_file : str
+        Path to a csv file containing equations.
+
+    binary_operators : list[str], default=["+", "-", "*", "/"]
+        The same binary operators used when creating the model.
+
+    unary_operators : list[str], default=None
+        The same unary operators used when creating the model.
+
+    n_features_in : int
+        Number of features passed to the model.
+
+    feature_names_in : list[str], default=None
+        Names of the features passed to the model.
+
+    selection_mask : list[bool], default=None
+        If using select_k_features, you must pass `model.selection_mask_` here.
+
+    nout : int, default=1
+        Number of outputs of the model.
+
+    pysr_kwargs : dict
+        Any other keyword arguments to initialize the PySRRegressor object.
+
+    Returns
+    -------
+    model : PySRRegressor
+        The model with fitted equations.
+    """
+
+    # TODO: copy .bkup file if exists.
+    model = PySRRegressor(
+        equation_file=equation_file,
+        binary_operators=binary_operators,
+        unary_operators=unary_operators,
+        **pysr_kwargs,
+    )
+
+    model.equation_file_ = equation_file
+    model.nout_ = nout
+    model.n_features_in_ = n_features_in
+
+    if feature_names_in is None:
+        model.feature_names_in_ = [f"x{i}" for i in range(n_features_in)]
+    else:
+        assert len(feature_names_in) == n_features_in
+        model.feature_names_in_ = feature_names_in
+
+    if selection_mask is None:
+        model.selection_mask_ = np.ones(n_features_in, dtype=bool)
+    else:
+        model.selection_mask_ = selection_mask
+
+    model.refresh()
+
+    return model

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -2061,9 +2061,9 @@ def run_feature_selection(X, y, select_k_features, random_state=None):
 def load(
     equation_file,
     *,
-    binary_operators,
-    unary_operators,
-    n_features_in,
+    binary_operators=None,
+    unary_operators=None,
+    n_features_in=None,
     feature_names_in=None,
     selection_mask=None,
     nout=1,
@@ -2097,12 +2097,33 @@ def load(
 
     pysr_kwargs : dict
         Any other keyword arguments to initialize the PySRRegressor object.
+        These will overwrite those stored in the pickle file.
 
     Returns
     -------
     model : PySRRegressor
         The model with fitted equations.
     """
+    # Try to load model from <equation_file>.pkl
+    print(f"Checking if {equation_file}.pkl exists...")
+    if os.path.exists(str(equation_file) + ".pkl"):
+        assert binary_operators is None
+        assert unary_operators is None
+        assert n_features_in is None
+        with open(str(equation_file) + ".pkl", "rb") as f:
+            model = pkl.load(f)
+        model.set_params(**pysr_kwargs)
+        model.refresh()
+        return model
+
+    # Else, we re-create it.
+    print(
+        f"{equation_file}.pkl does not exist, "
+        "so we must create the model from scratch."
+    )
+    assert binary_operators is not None
+    assert unary_operators is not None
+    assert n_features_in is not None
 
     # TODO: copy .bkup file if exists.
     model = PySRRegressor(

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -8,6 +8,7 @@ import re
 import tempfile
 import shutil
 from pathlib import Path
+import pickle as pkl
 from datetime import datetime
 import warnings
 from multiprocessing import cpu_count

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -2197,7 +2197,7 @@ def run_feature_selection(X, y, select_k_features, random_state=None):
 
 def _csv_filename_to_pkl_filename(csv_filename) -> str:
     # Assume that the csv filename is of the form "foo.csv"
-    assert csv_filename.endswith(".csv")
+    assert str(csv_filename).endswith(".csv")
 
     dirname = str(os.path.dirname(csv_filename))
     basename = str(os.path.basename(csv_filename))

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -926,7 +926,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
 
     def _checkpoint(self):
         """Saves the model's current state to a checkpoint file.
-        
+
         This should only be used internally by PySRRegressor."""
         # Save model state:
         self.show_pickle_warnings_ = False
@@ -2132,8 +2132,12 @@ def load(
         assert n_features_in is None
         with open(str(equation_file) + ".pkl", "rb") as f:
             model = pkl.load(f)
+        # Update any parameters if necessary, such as
+        # extra_sympy_mappings:
         model.set_params(**pysr_kwargs)
-        model.refresh()
+        if "equations_" not in model.__dict__ or model.equations_ is None:
+            model.refresh()
+
         return model
 
     # Else, we re-create it.

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1834,10 +1834,10 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             if self.nout_ > 1:
                 all_outputs = []
                 for i in range(1, self.nout_ + 1):
-                    df = pd.read_csv(
-                        str(self.equation_file_) + f".out{i}" + ".bkup",
-                        sep="|",
-                    )
+                    cur_filename = str(self.equation_file_) + f".out{i}" + ".bkup"
+                    if not os.path.exists(cur_filename):
+                        cur_filename = str(self.equation_file_) + f".out{i}"
+                    df = pd.read_csv(cur_filename, sep="|")
                     # Rename Complexity column to complexity:
                     df.rename(
                         columns={
@@ -1850,7 +1850,10 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
 
                     all_outputs.append(df)
             else:
-                all_outputs = [pd.read_csv(str(self.equation_file_) + ".bkup", sep="|")]
+                filename = str(self.equation_file_) + ".bkup"
+                if not os.path.exists(filename):
+                    filename = str(self.equation_file_)
+                all_outputs = [pd.read_csv(filename, sep="|")]
                 all_outputs[-1].rename(
                     columns={
                         "Complexity": "complexity",

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -883,7 +883,9 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             key: None if key == "raw_julia_state_" else value
             for key, value in state.items()
         }
-        if "equations_" in pickled_state:
+        if ("equations_" in pickled_state) and (
+            pickled_state["equations_"] is not None
+        ):
             pickled_state["output_torch_format"] = False
             pickled_state["output_jax_format"] = False
             if self.nout_ == 1:

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -2090,7 +2090,6 @@ def load(
         **pysr_kwargs,
     )
 
-    model.equation_file_ = equation_file
     model.nout_ = nout
     model.n_features_in_ = n_features_in
 
@@ -2105,6 +2104,6 @@ def load(
     else:
         model.selection_mask_ = selection_mask
 
-    model.refresh()
+    model.refresh(checkpoint_file=equation_file)
 
     return model

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -2197,6 +2197,8 @@ def run_feature_selection(X, y, select_k_features, random_state=None):
 
 def _csv_filename_to_pkl_filename(csv_filename) -> str:
     # Assume that the csv filename is of the form "foo.csv"
+    assert csv_filename.endswith(".csv")
+
     dirname = str(os.path.dirname(csv_filename))
     basename = str(os.path.basename(csv_filename))
     base = str(os.path.splitext(basename)[0])

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1642,10 +1642,10 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         checkpoint_file : str, default=None
             Path to checkpoint hall of fame file to be loaded.
         """
-        check_is_fitted(self, attributes=["equation_file_"])
         if checkpoint_file:
             self.equation_file_ = checkpoint_file
             self.equation_file_contents_ = None
+        check_is_fitted(self, attributes=["equation_file_"])
         self.equations_ = self.get_hof()
 
     def predict(self, X, index=None):

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import sys
 import numpy as np
@@ -1928,7 +1929,9 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
 
         ret_outputs = []
 
-        for output in self.equation_file_contents_:
+        equation_file_contents = copy.deepcopy(self.equation_file_contents_)
+
+        for output in equation_file_contents:
 
             scores = []
             lastMSE = None

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -2111,6 +2111,7 @@ def load(
     # Try to load model from <equation_file>.pkl
     print(f"Checking if {equation_file}.pkl exists...")
     if os.path.exists(str(equation_file) + ".pkl"):
+        print(f"Loading model from {equation_file}.pkl.")
         assert binary_operators is None
         assert unary_operators is None
         assert n_features_in is None

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1623,6 +1623,11 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             y,
         )
 
+        # Save model state:
+        self.show_pickle_warnings_ = False
+        with open(str(self.equation_file_) + ".pkl", "wb") as f:
+            pkl.dump(self, f)
+        self.show_pickle_warnings_ = True
         # Fitting procedure
         return self._run(X, y, mutated_params, weights=weights, seed=seed)
 

--- a/test/test.py
+++ b/test/test.py
@@ -290,24 +290,24 @@ class TestPipeline(unittest.TestCase):
         4|0.104823045|pow_abs(2.2683423, cos(f3))"""
         # Strip the indents:
         csv_file_data = "\n".join([l.strip() for l in csv_file_data.split("\n")])
-        rand_dir = Path(tempfile.mkdtemp())
-        equation_filename = rand_dir / "equation.csv"
-        with open(equation_filename, "w") as f:
-            f.write(csv_file_data)
-        with open(str(equation_filename) + ".bkup", "w") as f:
-            f.write(csv_file_data)
-        model = load(
-            equation_filename,
-            n_features_in=5,
-            feature_names_in=["f0", "f1", "f2", "f3", "f4"],
-            binary_operators=["+", "*", "/", "-", "^"],
-            unary_operators=["cos"],
-        )
-        X = self.rstate.rand(100, 5)
-        y_truth = 2.2683423 ** np.cos(X[:, 3])
-        y_test = model.predict(X, 2)
 
-        np.testing.assert_allclose(y_truth, y_test)
+        for from_backup in [False, True]:
+            rand_dir = Path(tempfile.mkdtemp())
+            equation_filename = str(rand_dir / "equation.csv")
+            with open(equation_filename + (".bkup" if from_backup else ""), "w") as f:
+                f.write(csv_file_data)
+            model = load(
+                equation_filename,
+                n_features_in=5,
+                feature_names_in=["f0", "f1", "f2", "f3", "f4"],
+                binary_operators=["+", "*", "/", "-", "^"],
+                unary_operators=["cos"],
+            )
+            X = self.rstate.rand(100, 5)
+            y_truth = 2.2683423 ** np.cos(X[:, 3])
+            y_test = model.predict(X, 2)
+
+            np.testing.assert_allclose(y_truth, y_test)
 
     def test_load_model_simple(self):
         # Test that we can simply load a model from its equation file.

--- a/test/test.py
+++ b/test/test.py
@@ -140,7 +140,7 @@ class TestPipeline(unittest.TestCase):
         # These tests are flaky, so don't fail test:
         try:
             np.testing.assert_almost_equal(
-                model.predict(X.copy())[:, 0], X[:, 0] ** 2, decimal=4
+                model.predict(X.copy())[:, 0], X[:, 0] ** 2, decimal=3
             )
         except AssertionError:
             print("Error in test_multioutput_weighted_with_callable_temp_equation")
@@ -149,7 +149,7 @@ class TestPipeline(unittest.TestCase):
 
         try:
             np.testing.assert_almost_equal(
-                model.predict(X.copy())[:, 1], X[:, 1] ** 2, decimal=4
+                model.predict(X.copy())[:, 1], X[:, 1] ** 2, decimal=3
             )
         except AssertionError:
             print("Error in test_multioutput_weighted_with_callable_temp_equation")
@@ -401,7 +401,7 @@ class TestBest(unittest.TestCase):
         X = self.X
         y = self.y
         for f in [self.model.predict, self.equations_.iloc[-1]["lambda_format"]]:
-            np.testing.assert_almost_equal(f(X), y, decimal=4)
+            np.testing.assert_almost_equal(f(X), y, decimal=3)
 
 
 class TestFeatureSelection(unittest.TestCase):

--- a/test/test.py
+++ b/test/test.py
@@ -12,6 +12,7 @@ import pandas as pd
 import warnings
 import pickle as pkl
 import tempfile
+from pathlib import Path
 
 DEFAULT_PARAMS = inspect.signature(PySRRegressor.__init__).parameters
 DEFAULT_NITERATIONS = DEFAULT_PARAMS["niterations"].default
@@ -289,12 +290,14 @@ class TestPipeline(unittest.TestCase):
         4|0.104823045|pow_abs(2.2683423, cos(f3))"""
         # Strip the indents:
         csv_file_data = "\n".join([l.strip() for l in csv_file_data.split("\n")])
-        with open("equation_file.csv", "w") as f:
+        rand_dir = Path(tempfile.mkdtemp())
+        equation_filename = rand_dir / "equation.csv"
+        with open(equation_filename, "w") as f:
             f.write(csv_file_data)
-        with open("equation_file.csv.bkup", "w") as f:
+        with open(equation_filename + ".bkup", "w") as f:
             f.write(csv_file_data)
         model = load(
-            "equation_file.csv",
+            equation_filename,
             n_features_in=5,
             feature_names_in=["f0", "f1", "f2", "f3", "f4"],
             binary_operators=["+", "*", "/", "-", "^"],

--- a/test/test.py
+++ b/test/test.py
@@ -336,6 +336,16 @@ class TestPipeline(unittest.TestCase):
 
         np.testing.assert_allclose(model.predict(self.X), model2.predict(self.X))
 
+        # Try again, but using only the pickle file:
+        for file_to_delete in [str(equation_file), str(equation_file) + ".bkup"]:
+            if os.path.exists(file_to_delete):
+                os.remove(file_to_delete)
+
+        model3 = load(
+            model.equation_file_, extra_sympy_mappings={"sq": lambda x: x**2}
+        )
+        np.testing.assert_allclose(model.predict(self.X), model3.predict(self.X))
+
 
 class TestBest(unittest.TestCase):
     def setUp(self):

--- a/test/test.py
+++ b/test/test.py
@@ -294,7 +294,7 @@ class TestPipeline(unittest.TestCase):
         equation_filename = rand_dir / "equation.csv"
         with open(equation_filename, "w") as f:
             f.write(csv_file_data)
-        with open(equation_filename + ".bkup", "w") as f:
+        with open(str(equation_filename) + ".bkup", "w") as f:
             f.write(csv_file_data)
         model = load(
             equation_filename,

--- a/test/test.py
+++ b/test/test.py
@@ -4,7 +4,7 @@ import inspect
 import unittest
 import numpy as np
 from sklearn import model_selection
-from pysr import PySRRegressor, load
+from pysr import PySRRegressor
 from pysr.sr import (
     run_feature_selection,
     _handle_feature_selection,
@@ -300,7 +300,7 @@ class TestPipeline(unittest.TestCase):
             equation_filename = str(rand_dir / "equation.csv")
             with open(equation_filename + (".bkup" if from_backup else ""), "w") as f:
                 f.write(csv_file_data)
-            model = load(
+            model = PySRRegressor.from_file(
                 equation_filename,
                 n_features_in=5,
                 feature_names_in=["f0", "f1", "f2", "f3", "f4"],
@@ -334,7 +334,7 @@ class TestPipeline(unittest.TestCase):
 
         # lambda functions are removed from the pickling, so we need
         # to pass it during the loading:
-        model2 = load(
+        model2 = PySRRegressor.from_file(
             model.equation_file_, extra_sympy_mappings={"sq": lambda x: x**2}
         )
 
@@ -346,7 +346,7 @@ class TestPipeline(unittest.TestCase):
                 os.remove(file_to_delete)
 
         pickle_file = rand_dir / "equations.pkl"
-        model3 = load(
+        model3 = PySRRegressor.from_file(
             model.equation_file_, extra_sympy_mappings={"sq": lambda x: x**2}
         )
         np.testing.assert_allclose(model.predict(self.X), model3.predict(self.X))

--- a/test/test.py
+++ b/test/test.py
@@ -5,7 +5,11 @@ import unittest
 import numpy as np
 from sklearn import model_selection
 from pysr import PySRRegressor, load
-from pysr.sr import run_feature_selection, _handle_feature_selection
+from pysr.sr import (
+    run_feature_selection,
+    _handle_feature_selection,
+    _csv_filename_to_pkl_filename,
+)
 from sklearn.utils.estimator_checks import check_estimator
 import sympy
 import pandas as pd
@@ -341,6 +345,7 @@ class TestPipeline(unittest.TestCase):
             if os.path.exists(file_to_delete):
                 os.remove(file_to_delete)
 
+        pickle_file = rand_dir / "equations.pkl"
         model3 = load(
             model.equation_file_, extra_sympy_mappings={"sq": lambda x: x**2}
         )
@@ -429,6 +434,20 @@ class TestFeatureSelection(unittest.TestCase):
 
 class TestMiscellaneous(unittest.TestCase):
     """Test miscellaneous functions."""
+
+    def test_csv_to_pkl_conversion(self):
+        """Test that csv filename to pkl filename works as expected."""
+        tmpdir = Path(tempfile.mkdtemp())
+        equation_file = tmpdir / "equations.389479384.28378374.csv"
+        expected_pkl_file = tmpdir / "equations.389479384.28378374.pkl"
+
+        # First, test inputting the paths:
+        test_pkl_file = _csv_filename_to_pkl_filename(equation_file)
+        self.assertEqual(test_pkl_file, str(expected_pkl_file))
+
+        # Next, test inputting the strings.
+        test_pkl_file = _csv_filename_to_pkl_filename(str(equation_file))
+        self.assertEqual(test_pkl_file, str(expected_pkl_file))
 
     def test_deprecation(self):
         """Ensure that deprecation works as expected.

--- a/test/test_jax.py
+++ b/test/test_jax.py
@@ -76,7 +76,7 @@ class TestJAX(unittest.TestCase):
         np.testing.assert_almost_equal(
             np.array(jformat["callable"](jnp.array(X), jformat["parameters"])),
             np.square(np.cos(X[:, 1])),  # Select feature 1
-            decimal=4,
+            decimal=3,
         )
 
     def test_feature_selection_custom_operators(self):


### PR DESCRIPTION
This makes it easier to load models directly from a saved equation file. There are two ways to use this:

1. You can use `pysr.load(...)` to load from a standalone csv file of equations. However, you must pass a few different attributes here, to initialize the model: `binary_operators`, `unary_operators`, and `n_features_in`. If you have custom variable names, you also need to pass that, as well as `nout` if the number of outputs is not 1.
2. `PySRRegressor` will now automatically create a pickle file of the model parameters when running `fit(...)`. This has the same name as the equation file, but with a `.pkl` extension. This lets you run, e.g., `pysr.load("equations.csv")`, and have everything loaded from the equation. This also loads all the other parameters. (Although, you also need to pass `extra_sympy_mappings` and `extra_torch_mappings` as they are unpicklable).

@tttc3 what do you think of this?

I am also wondering if it might be more intuitive to have a `PySRRegressor.from_file(...)` constructor.