### PR TITLE
Switch to comma-based csv format

### DIFF
--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -469,7 +469,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         Whether to use a progress bar instead of printing to stdout.
 
     equation_file : str, default=None
-        Where to save the files (.csv separated by |).
+        Where to save the files (with `.csv` extension).
 
     temp_equation_file : bool, default=False
         Whether to put the hall of fame file in the temp directory.

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1969,12 +1969,12 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                     cur_filename = str(self.equation_file_) + f".out{i}" + ".bkup"
                     if not os.path.exists(cur_filename):
                         cur_filename = str(self.equation_file_) + f".out{i}"
-                    df = pd.read_csv(cur_filename, sep="|")
+                    df = pd.read_csv(cur_filename)
                     # Rename Complexity column to complexity:
                     df.rename(
                         columns={
                             "Complexity": "complexity",
-                            "MSE": "loss",
+                            "Loss": "loss",
                             "Equation": "equation",
                         },
                         inplace=True,
@@ -1985,11 +1985,11 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                 filename = str(self.equation_file_) + ".bkup"
                 if not os.path.exists(filename):
                     filename = str(self.equation_file_)
-                all_outputs = [pd.read_csv(filename, sep="|")]
+                all_outputs = [pd.read_csv(filename)]
                 all_outputs[-1].rename(
                     columns={
                         "Complexity": "complexity",
-                        "MSE": "loss",
+                        "Loss": "loss",
                         "Equation": "equation",
                     },
                     inplace=True,

--- a/pysr/version.py
+++ b/pysr/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.9.5"
+__version__ = "0.10.0"
 __symbolic_regression_jl_version__ = "0.10.0"

--- a/pysr/version.py
+++ b/pysr/version.py
@@ -1,2 +1,2 @@
 __version__ = "0.9.5"
-__symbolic_regression_jl_version__ = "0.9.7"
+__symbolic_regression_jl_version__ = "0.10.0"

--- a/test/test.py
+++ b/test/test.py
@@ -288,10 +288,10 @@ class TestPipeline(unittest.TestCase):
     def test_load_model(self):
         """See if we can load a ran model from the equation file."""
         csv_file_data = """
-        Complexity|MSE|Equation
-        1|0.19951081|1.9762075
-        3|0.12717344|(f0 + 1.4724599)
-        4|0.104823045|pow_abs(2.2683423, cos(f3))"""
+        Complexity,Loss,Equation
+        1,0.19951081,"1.9762075"
+        3,0.12717344,"(f0 + 1.4724599)"
+        4,0.104823045,"pow_abs(2.2683423, cos(f3))\""""
         # Strip the indents:
         csv_file_data = "\n".join([l.strip() for l in csv_file_data.split("\n")])
 
@@ -379,7 +379,7 @@ class TestBest(unittest.TestCase):
         self.model.selection_mask_ = None
         self.model.feature_names_in_ = np.array(["x0", "x1"], dtype=object)
         equations["complexity loss equation".split(" ")].to_csv(
-            "equation_file.csv.bkup", sep="|"
+            "equation_file.csv.bkup"
         )
 
         self.model.refresh()

--- a/test/test_jax.py
+++ b/test/test_jax.py
@@ -34,13 +34,13 @@ class TestJAX(unittest.TestCase):
         equations = pd.DataFrame(
             {
                 "Equation": ["1.0", "cos(x1)", "square(cos(x1))"],
-                "MSE": [1.0, 0.1, 1e-5],
+                "Loss": [1.0, 0.1, 1e-5],
                 "Complexity": [1, 2, 3],
             }
         )
 
-        equations["Complexity MSE Equation".split(" ")].to_csv(
-            "equation_file.csv.bkup", sep="|"
+        equations["Complexity Loss Equation".split(" ")].to_csv(
+            "equation_file.csv.bkup"
         )
 
         model.refresh(checkpoint_file="equation_file.csv")
@@ -61,13 +61,13 @@ class TestJAX(unittest.TestCase):
         equations = pd.DataFrame(
             {
                 "Equation": ["1.0", "cos(x1)", "square(cos(x1))"],
-                "MSE": [1.0, 0.1, 1e-5],
+                "Loss": [1.0, 0.1, 1e-5],
                 "Complexity": [1, 2, 3],
             }
         )
 
-        equations["Complexity MSE Equation".split(" ")].to_csv(
-            "equation_file.csv.bkup", sep="|"
+        equations["Complexity Loss Equation".split(" ")].to_csv(
+            "equation_file.csv.bkup"
         )
 
         model.refresh(checkpoint_file="equation_file.csv")

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -49,13 +49,13 @@ class TestTorch(unittest.TestCase):
         equations = pd.DataFrame(
             {
                 "Equation": ["1.0", "cos(x1)", "square(cos(x1))"],
-                "MSE": [1.0, 0.1, 1e-5],
+                "Loss": [1.0, 0.1, 1e-5],
                 "Complexity": [1, 2, 3],
             }
         )
 
-        equations["Complexity MSE Equation".split(" ")].to_csv(
-            "equation_file.csv.bkup", sep="|"
+        equations["Complexity Loss Equation".split(" ")].to_csv(
+            "equation_file.csv.bkup"
         )
 
         model.refresh(checkpoint_file="equation_file.csv")
@@ -82,13 +82,13 @@ class TestTorch(unittest.TestCase):
         equations = pd.DataFrame(
             {
                 "Equation": ["1.0", "cos(x1)", "square(cos(x1))"],
-                "MSE": [1.0, 0.1, 1e-5],
+                "Loss": [1.0, 0.1, 1e-5],
                 "Complexity": [1, 2, 3],
             }
         )
 
-        equations["Complexity MSE Equation".split(" ")].to_csv(
-            "equation_file.csv.bkup", sep="|"
+        equations["Complexity Loss Equation".split(" ")].to_csv(
+            "equation_file.csv.bkup"
         )
 
         model.refresh(checkpoint_file="equation_file.csv")
@@ -133,13 +133,13 @@ class TestTorch(unittest.TestCase):
         equations = pd.DataFrame(
             {
                 "Equation": ["1.0", "mycustomoperator(x1)"],
-                "MSE": [1.0, 0.1],
+                "Loss": [1.0, 0.1],
                 "Complexity": [1, 2],
             }
         )
 
-        equations["Complexity MSE Equation".split(" ")].to_csv(
-            "equation_file_custom_operator.csv.bkup", sep="|"
+        equations["Complexity Loss Equation".split(" ")].to_csv(
+            "equation_file_custom_operator.csv.bkup"
         )
 
         model.set_params(


### PR DESCRIPTION
This is a long-desired change to the checkpoint format. Rather than "|" separators, which was used because "," appears inside the equation, this simply assumes the equation column is surrounded by quotations - which deactivates the commas.

For example,
```
Complexity|MSE|Equation
1|0.19951081|1.9762075
3|0.12717344|(f0 + 1.4724599)
4|0.104823045|pow_abs(2.2683423, cos(f3))
```
is now:
```
Complexity,Loss,Equation
1,0.19951081,"1.9762075"
3,0.12717344,"(f0 + 1.4724599)"
4,0.104823045,"pow_abs(2.2683423, cos(f3))"
```
which will correctly preview on various systems without having to specify the separator.

Fixes #120 