### PR TITLE
Change "best" model_selection to include a loss threshold

### DIFF
--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -2157,7 +2157,7 @@ def idx_model_selection(equations: pd.DataFrame, model_selection: str) -> int:
         chosen_idx = equations["loss"].idxmin()
     elif model_selection == "best":
         threshold = 1.5 * equations["loss"].min()
-        filtered_equations = equations.query(f"loss < {threshold}")
+        filtered_equations = equations.query(f"loss <= {threshold}")
         chosen_idx = filtered_equations["score"].idxmax()
     elif model_selection == "score":
         chosen_idx = equations["score"].idxmax()

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -211,9 +211,9 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         - `"accuracy"` selects the candidate model with the lowest loss
           (highest accuracy).
         - `"score"` selects the candidate model with the highest score.
-          Score is defined as the derivative of the log-loss with
+          Score is defined as the negated derivative of the log-loss with
           respect to complexity - if an expression has a much better
-          oss at a slightly higher complexity, it is preferred.
+          loss at a slightly higher complexity, it is preferred.
         - `"best"` selects the candidate model with the highest score
           among expressions with a loss better than at least 1.5x the
           most accurate model.

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -205,7 +205,9 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
     Parameters
     ----------
     model_selection : str, default="best"
-        Model selection criterion. Can be 'accuracy', 'best', or 'score'.
+        Model selection criterion when selecting a final expression from
+        the list of best expression at each complexity.
+        Can be 'accuracy', 'best', or 'score'.
         - `"accuracy"` selects the candidate model with the lowest loss
           (highest accuracy).
         - `"score"` selects the candidate model with the highest score.

--- a/test/test.py
+++ b/test/test.py
@@ -9,6 +9,7 @@ from pysr.sr import (
     run_feature_selection,
     _handle_feature_selection,
     _csv_filename_to_pkl_filename,
+    idx_model_selection,
 )
 from sklearn.utils.estimator_checks import check_estimator
 import sympy
@@ -402,6 +403,20 @@ class TestBest(unittest.TestCase):
         y = self.y
         for f in [self.model.predict, self.equations_.iloc[-1]["lambda_format"]]:
             np.testing.assert_almost_equal(f(X), y, decimal=3)
+
+    def test_all_selection_strategies(self):
+        equations = pd.DataFrame(
+            dict(
+                loss=[1.0, 0.1, 0.01, 0.001 * 1.4, 0.001],
+                score=[0.5, 1.0, 0.5, 0.5, 0.3],
+            )
+        )
+        idx_accuracy = idx_model_selection(equations, "accuracy")
+        self.assertEqual(idx_accuracy, 4)
+        idx_best = idx_model_selection(equations, "best")
+        self.assertEqual(idx_best, 3)
+        idx_score = idx_model_selection(equations, "score")
+        self.assertEqual(idx_score, 1)
 
 
 class TestFeatureSelection(unittest.TestCase):


### PR DESCRIPTION
In PySR `v0.10.0`, this should change the definition of `model_selection="best"` to also include a loss threshold. Sometimes, just returning the equation with the max score will have a very bad loss - perhaps because a very simple equation just happens to have a large derivative in the loss-complexity curve. 

This PR changes this so that only equations with `loss < 1.5 * min_loss` are considered. This is what was used by PySR in the GECCO contest and seemed to work well in that situation.

To select purely based on score, one can now use `model_selection="score"`

This PR also refactors the model_selection to avoid shotgun edits.