### PR TITLE
Fix install for Julia <=1.6

### DIFF
--- a/.github/workflows/CI_Windows.yml
+++ b/.github/workflows/CI_Windows.yml
@@ -26,7 +26,7 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        julia-version: ['1.7.1']
+        julia-version: ['1.6', '1.7.1']
         python-version: ['3.9']
         os: [windows-2019]
     

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -32,10 +32,8 @@ def load_juliainfo():
 
 
 def _set_julia_project_env(julia_project, is_shared):
-    juliainfo = load_juliainfo()
-
     if is_shared:
-        if is_julia_version_greater_eq(juliainfo, (1, 7, 0)):
+        if is_julia_version_greater_eq(version=(1, 7, 0)):
             os.environ["JULIA_PROJECT"] = "@" + str(julia_project)
     else:
         os.environ["JULIA_PROJECT"] = str(julia_project)
@@ -65,8 +63,7 @@ def install(julia_project=None, quiet=False):  # pragma: no cover
     Main.eval("using Pkg")
 
     io = "devnull" if quiet else "stderr"
-    juliainfo = load_juliainfo()
-    io_arg = f"io={io}" if is_julia_version_greater_eq(juliainfo, (1, 6, 0)) else ""
+    io_arg = f"io={io}" if is_julia_version_greater_eq(version=(1, 6, 0)) else ""
 
     # Can't pass IO to Julia call as it evaluates to PyObject, so just directly
     # use Main.eval:
@@ -111,8 +108,10 @@ def _get_julia_project(julia_project):
     return julia_project, is_shared
 
 
-def is_julia_version_greater_eq(juliainfo, version=(1, 6, 0)):
+def is_julia_version_greater_eq(juliainfo=None, version=(1, 6, 0)):
     """Check if Julia version is greater than specified version."""
+    if juliainfo is None:
+        juliainfo = load_juliainfo()
     current_version = (
         juliainfo.version_major,
         juliainfo.version_minor,

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -28,6 +28,12 @@ def load_juliainfo():
     return juliainfo
 
 
+def reset_juliainfo():
+    """Reset juliainfo to None."""
+    global juliainfo
+    juliainfo = None
+
+
 def _set_julia_project_env(julia_project, is_shared):
     if is_shared:
         if is_julia_version_greater_eq(version=(1, 7, 0)):
@@ -78,6 +84,9 @@ def install(julia_project=None, quiet=False):  # pragma: no cover
             "It is recommended to restart Python after installing PySR's dependencies,"
             " so that the Julia environment is properly initialized."
         )
+
+    # Ensure that the JuliaInfo is reset:
+    reset_juliainfo()
 
 
 def import_error_string(julia_project=None):

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -11,7 +11,7 @@ juliainfo = None
 julia_initialized = False
 
 
-def load_juliainfo():
+def _load_juliainfo():
     """Execute julia.core.JuliaInfo.load(), and store as juliainfo."""
     global juliainfo
 
@@ -63,14 +63,14 @@ def install(julia_project=None, quiet=False):  # pragma: no cover
     import julia
 
     # Set JULIA_PROJECT so that we install in the pysr environment
-    julia_project, is_shared = _get_julia_project(julia_project)
+    julia_project, is_shared = _process_julia_project(julia_project)
     _set_julia_project_env(julia_project, is_shared)
 
     julia.install(quiet=quiet)
 
     if is_shared:
         # is_shared is only true if the julia_project arg was None
-        # See _get_julia_project
+        # See _process_julia_project
         Main = init_julia(None)
     else:
         Main = init_julia(julia_project)
@@ -98,7 +98,7 @@ def install(julia_project=None, quiet=False):  # pragma: no cover
         )
 
 
-def import_error_string(julia_project=None):
+def _import_error_string(julia_project=None):
     s = """
     Required dependencies are not installed or built.  Run the following code in the Python REPL:
 
@@ -113,7 +113,7 @@ def import_error_string(julia_project=None):
     return s
 
 
-def _get_julia_project(julia_project):
+def _process_julia_project(julia_project):
     if julia_project is None:
         is_shared = True
         julia_project = f"pysr-{__version__}"
@@ -135,7 +135,7 @@ def is_julia_version_greater_eq(juliainfo=None, version=(1, 6, 0)):
     return current_version >= version
 
 
-def check_for_conflicting_libraries():  # pragma: no cover
+def _check_for_conflicting_libraries():  # pragma: no cover
     """Check whether there are conflicting modules, and display warnings."""
     # See https://github.com/pytorch/pytorch/issues/78829: importing
     # pytorch before running `pysr.fit` causes a segfault.
@@ -155,11 +155,11 @@ def init_julia(julia_project=None):
     global julia_initialized
 
     if not julia_initialized:
-        check_for_conflicting_libraries()
+        _check_for_conflicting_libraries()
 
     from julia.core import JuliaInfo, UnsupportedPythonError
 
-    julia_project, is_shared = _get_julia_project(julia_project)
+    julia_project, is_shared = _process_julia_project(julia_project)
     _set_julia_project_env(julia_project, is_shared)
 
     try:
@@ -171,7 +171,7 @@ def init_julia(julia_project=None):
         )
 
     if not info.is_pycall_built():
-        raise ImportError(import_error_string())
+        raise ImportError(_import_error_string())
 
     Main = None
     try:

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -126,7 +126,7 @@ def _process_julia_project(julia_project):
 def is_julia_version_greater_eq(juliainfo=None, version=(1, 6, 0)):
     """Check if Julia version is greater than specified version."""
     if juliainfo is None:
-        juliainfo = load_juliainfo()
+        juliainfo = _load_juliainfo()
     current_version = (
         juliainfo.version_major,
         juliainfo.version_minor,
@@ -206,7 +206,7 @@ def _add_sr_to_julia_project(Main, io_arg):
 
 
 def _escape_filename(filename):
-    """Turns a file into a string representation with correctly escaped backslashes"""
+    """Turn a path into a string with correctly escaped backslashes."""
     str_repr = str(filename)
     str_repr = str_repr.replace("\\", "\\\\")
     return str_repr

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -25,9 +25,6 @@ def load_juliainfo():
                 f"Julia is not installed in your PATH. Please install Julia and add it to your PATH.\n\nCurrent PATH: {env_path}",
             )
 
-        if not juliainfo.is_pycall_built():
-            raise ImportError(import_error_string())
-
     return juliainfo
 
 
@@ -144,6 +141,8 @@ def init_julia(julia_project=None):
         check_for_conflicting_libraries()
 
     juliainfo = load_juliainfo()
+    if not juliainfo.is_pycall_built():
+        raise ImportError(import_error_string())
     julia_project, is_shared = _get_julia_project(julia_project)
     _set_julia_project_env(julia_project, is_shared)
 

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1440,7 +1440,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             julia_project, is_shared = _get_julia_project(self.julia_project)
             Main.eval("using Pkg")
             io = "devnull" if update_verbosity == 0 else "stderr"
-            io_arg = f"io={io}" if is_julia_version_greater_eq(Main, (1, 6, 0)) else ""
+            io_arg = f"io={io}" if is_julia_version_greater_eq(version=(1, 6, 0)) else ""
 
             Main.eval(
                 f'Pkg.activate("{_escape_filename(julia_project)}", shared = Bool({int(is_shared)}), {io_arg})'

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -27,7 +27,7 @@ from .julia_helpers import (
     is_julia_version_greater_eq,
     _escape_filename,
     _add_sr_to_julia_project,
-    import_error_string,
+    _import_error_string,
 )
 from .export_numpy import CallableEquation
 from .export_latex import generate_single_table, generate_multiple_tables, to_latex
@@ -1455,7 +1455,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                         _add_sr_to_julia_project(Main, io_arg)
                     Main.eval(f"Pkg.resolve({io_arg})")
                 except (JuliaError, RuntimeError) as e:
-                    raise ImportError(import_error_string(julia_project)) from e
+                    raise ImportError(_import_error_string(julia_project)) from e
             Main.eval("using SymbolicRegression")
 
             Main.plus = Main.eval("(+)")

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1440,7 +1440,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             julia_project, is_shared = _get_julia_project(self.julia_project)
             Main.eval("using Pkg")
             io = "devnull" if update_verbosity == 0 else "stderr"
-            io_arg = f"io={io}" if is_julia_version_greater_eq(Main, "1.6") else ""
+            io_arg = f"io={io}" if is_julia_version_greater_eq(Main, (1, 6, 0)) else ""
 
             Main.eval(
                 f'Pkg.activate("{_escape_filename(julia_project)}", shared = Bool({int(is_shared)}), {io_arg})'

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1440,7 +1440,9 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             julia_project, is_shared = _get_julia_project(self.julia_project)
             Main.eval("using Pkg")
             io = "devnull" if update_verbosity == 0 else "stderr"
-            io_arg = f"io={io}" if is_julia_version_greater_eq(version=(1, 6, 0)) else ""
+            io_arg = (
+                f"io={io}" if is_julia_version_greater_eq(version=(1, 6, 0)) else ""
+            )
 
             Main.eval(
                 f'Pkg.activate("{_escape_filename(julia_project)}", shared = Bool({int(is_shared)}), {io_arg})'

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -23,7 +23,7 @@ from sklearn.utils.validation import (
 
 from .julia_helpers import (
     init_julia,
-    _get_julia_project,
+    _process_julia_project,
     is_julia_version_greater_eq,
     _escape_filename,
     _add_sr_to_julia_project,
@@ -1437,7 +1437,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             cluster_manager = Main.eval(f"addprocs_{cluster_manager}")
 
         if not already_ran:
-            julia_project, is_shared = _get_julia_project(self.julia_project)
+            julia_project, is_shared = _process_julia_project(self.julia_project)
             Main.eval("using Pkg")
             io = "devnull" if update_verbosity == 0 else "stderr"
             io_arg = (


### PR DESCRIPTION
If the Julia project is a shared env, the variable `JULIA_PROJECT` will only be set to `@pysr-{version}` if Julia >= 1.7. Otherwise, it will not be set, and the activation performed explicitly.

This also includes a cleaner version check which doesn't require Julia to be started.

@mkitti do you think you could take a look at this?