### PR TITLE
Allow custom shared projects for `julia_project`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -69,6 +69,8 @@ jobs:
         run: pip install torch # (optional import)
       - name: "Run Torch tests"
         run: coverage run --append --source=pysr --omit='*/feynman_problems.py' -m unittest test.test_torch
+      - name: "Run custom env tests"
+        run: coverage run --append --source=pysr --omit='*/feynman_problems.py' -m unittest test.test_env
       - name: Coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -121,6 +123,8 @@ jobs:
         run: python3 -m pip install coverage coveralls
       - name: "Run tests"
         run: coverage run --append --source=pysr --omit='*/feynman_problems.py' -m unittest test.test
+      - name: "Run custom env tests"
+        run: coverage run --append --source=pysr --omit='*/feynman_problems.py' -m unittest test.test_env
       - name: Coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI_Windows.yml
+++ b/.github/workflows/CI_Windows.yml
@@ -63,3 +63,5 @@ jobs:
         run: pip install torch # (optional import)
       - name: "Run Torch tests"
         run: python -m unittest test.test_torch
+      - name: "Run custom env tests"
+        run: python -m unittest test.test_env

--- a/.github/workflows/CI_conda_forge.yml
+++ b/.github/workflows/CI_conda_forge.yml
@@ -34,4 +34,4 @@ jobs:
       - name: "Install pysr-forge"
         run: conda activate test && mamba install pysr
       - name: "Run tests"
-        run: conda activate test && python3 -m unittest test.test
+        run: conda activate test && python3 -m unittest test.test && python3 -m unittest test.test_env

--- a/.github/workflows/CI_docker.yml
+++ b/.github/workflows/CI_docker.yml
@@ -38,4 +38,4 @@ jobs:
       - name: Build docker
         run: docker build -t pysr --build-arg ARCH=${{ matrix.arch }} --build-arg VERSION=${{ matrix.julia-version }} --build-arg PYVERSION=${{ matrix.python-version }} .
       - name: Test docker
-        run: docker run --platform=${{ matrix.arch }} --rm pysr /bin/bash -c 'python3 -m unittest test.test'
+        run: docker run --platform=${{ matrix.arch }} --rm pysr /bin/bash -c 'python3 -m unittest test.test && python3 -m unittest test.test_env'

--- a/.github/workflows/CI_docker_large_nightly.yml
+++ b/.github/workflows/CI_docker_large_nightly.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Build docker
         run: docker build -t pysr --build-arg ARCH=${{ matrix.arch }} --build-arg VERSION=${{ matrix.julia-version }} --build-arg PYVERSION=${{ matrix.python-version }} .
       - name: Test docker
-        run: docker run --platform=${{ matrix.arch }} --rm pysr /bin/bash -c 'python3 -m unittest test.test'
+        run: docker run --platform=${{ matrix.arch }} --rm pysr /bin/bash -c 'python3 -m unittest test.test && python3 -m unittest test.test_env'

--- a/.github/workflows/CI_large_nightly.yml
+++ b/.github/workflows/CI_large_nightly.yml
@@ -41,4 +41,4 @@ jobs:
             python setup.py install
             python -c 'import pysr; pysr.install()'
       - name: "Run tests"
-        run: python -m unittest test.test
+        run: python -m unittest test.test && python -m unittest test.test_env

--- a/.github/workflows/CI_mac.yml
+++ b/.github/workflows/CI_mac.yml
@@ -67,3 +67,5 @@ jobs:
         run: pip install torch # (optional import)
       - name: "Run Torch tests"
         run: python -m unittest test.test_torch
+      - name: "Run custom env tests"
+        run: python -m unittest test.test_env

--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,5 @@ dependencies:
   - scikit-learn
   - setuptools
   - pyjulia
-  - openlibm<0.8.0
+  - openlibm
+  - openspecfun

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -200,6 +200,7 @@ def init_julia(julia_project=None, quiet=False):
 
 
 def _add_sr_to_julia_project(Main, io_arg):
+    Main.eval("using Pkg")
     Main.sr_spec = Main.PackageSpec(
         name="SymbolicRegression",
         url="https://github.com/MilesCranmer/SymbolicRegression.jl",

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -33,7 +33,9 @@ def _get_julia_env_dir():
     # Have to manually get env dir:
     try:
         julia_env_dir_str = subprocess.run(
-            ["julia", "-e using Pkg; print(Pkg.envdir())"], capture_output=True
+            ["julia", "-e using Pkg; print(Pkg.envdir())"],
+            capture_output=True,
+            env=os.environ,
         ).stdout.decode()
     except FileNotFoundError:
         env_path = os.environ["PATH"]

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -118,6 +118,9 @@ def _process_julia_project(julia_project):
     if julia_project is None:
         is_shared = True
         julia_project = f"pysr-{__version__}"
+    elif julia_project[0] == "@":
+        is_shared = True
+        julia_project = julia_project[1:]
     else:
         is_shared = False
         julia_project = Path(julia_project)

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -53,6 +53,7 @@ def _set_julia_project_env(julia_project, is_shared):
     else:
         os.environ["JULIA_PROJECT"] = str(julia_project)
 
+
 def _get_io_arg(quiet):
     io = "devnull" if quiet else "stderr"
     io_arg = f"io={io}" if is_julia_version_greater_eq(version=(1, 6, 0)) else ""

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -21,8 +21,12 @@ class TestJuliaProject(unittest.TestCase):
                 os.environ["JULIA_DEPOT_PATH"] = tmpdir
             else:
                 old_env = os.environ["JULIA_DEPOT_PATH"]
-                os.environ["JULIA_DEPOT_PATH"] = f"{tmpdir}:{os.environ['JULIA_DEPOT_PATH']}"
-            Main.eval(f'pushfirst!(DEPOT_PATH, "{julia_helpers._escape_filename(tmpdir)}")')
+                os.environ[
+                    "JULIA_DEPOT_PATH"
+                ] = f"{tmpdir}:{os.environ['JULIA_DEPOT_PATH']}"
+            Main.eval(
+                f'pushfirst!(DEPOT_PATH, "{julia_helpers._escape_filename(tmpdir)}")'
+            )
             test_env_name = "@pysr_test_env"
             julia_helpers.install(julia_project=test_env_name)
             Main = julia_helpers.init_julia(julia_project=test_env_name)
@@ -30,7 +34,7 @@ class TestJuliaProject(unittest.TestCase):
             # Try to use env:
             Main.eval("using SymbolicRegression")
             Main.eval("using Pkg")
-            
+
             # Assert we actually loaded it:
             cur_project_dir = Main.eval("splitdir(dirname(Base.active_project()))[1]")
             potential_shared_project_dirs = Main.eval("Pkg.envdir(DEPOT_PATH[1])")

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -12,10 +12,10 @@ class TestJuliaProject(unittest.TestCase):
             # Create a temp depot to store julia packages (and our custom env)
             Main = julia_helpers.init_julia()
             Main.eval(
-                f'pushfirst!(DEPOT_PATH, "{julia_helpers._escape_filename(tmpdir)}")'
+                f'pushfirst!(DEPOT_PATH, "{julia_helpers._escape_filename(tmpdir.name)}")'
             )
             test_env_name = "@pysr_test_env"
-            julia_helpers.install(julia_project=test_env_name, quiet=True)
+            julia_helpers.install(julia_project=test_env_name)
             Main = julia_helpers.init_julia(julia_project=test_env_name)
             Main.eval("using SymbolicRegression")
             Main.eval("using Pkg")

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -1,0 +1,15 @@
+"""Contains tests for creating and initializing custom Julia projects"""
+
+import unittest
+from pysr import julia_helpers
+
+
+class TestJuliaProject(unittest.TestCase):
+    def test_custom_shared_env(self):
+        """Test that we can use PySR in a custom shared env"""
+        test_env_name = "@pysr_test_env"
+        julia_helpers.install(julia_project=test_env_name, quiet=True)
+        Main = julia_helpers.init_julia(julia_project=test_env_name)
+        Main.eval("using SymbolicRegression")
+        # TODO: Test that we are actually in the correct env.
+        # TODO: Delete the env at the end.

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -11,5 +11,8 @@ class TestJuliaProject(unittest.TestCase):
         julia_helpers.install(julia_project=test_env_name, quiet=True)
         Main = julia_helpers.init_julia(julia_project=test_env_name)
         Main.eval("using SymbolicRegression")
-        # TODO: Test that we are actually in the correct env.
+        Main.eval("using Pkg")
+        cur_project_dir = Main.eval("splitdir(dirname(Base.active_project()))[1]")
+        potential_shared_project_dirs = Main.eval("Pkg.envdir.(DEPOT_PATH)")
+        self.assertIn(cur_project_dir, potential_shared_project_dirs)
         # TODO: Delete the env at the end.

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -1,19 +1,23 @@
-"""Contains tests for creating and initializing custom Julia projects"""
+"""Contains tests for creating and initializing custom Julia projects."""
 
 import unittest
+import os
 from pysr import julia_helpers
 from tempfile import TemporaryDirectory
 
 
 class TestJuliaProject(unittest.TestCase):
+    """Various tests for working with Julia projects."""
+
     def test_custom_shared_env(self):
-        """Test that we can use PySR in a custom shared env"""
+        """Test that we can use PySR in a custom shared env."""
         with TemporaryDirectory() as tmpdir:
             # Create a temp depot to store julia packages (and our custom env)
             Main = julia_helpers.init_julia()
-            Main.eval(
-                f'pushfirst!(DEPOT_PATH, "{julia_helpers._escape_filename(tmpdir.name)}")'
-            )
+            if "JULIA_DEPOT_PATH" not in os.environ:
+                os.environ["JULIA_DEPOT_PATH"] = tmpdir
+            else:
+                os.environ["JULIA_DEPOT_PATH"] = f"{tmpdir}:{os.environ['JULIA_DEPOT_PATH']}"
             test_env_name = "@pysr_test_env"
             julia_helpers.install(julia_project=test_env_name)
             Main = julia_helpers.init_julia(julia_project=test_env_name)

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -14,20 +14,29 @@ class TestJuliaProject(unittest.TestCase):
         with TemporaryDirectory() as tmpdir:
             # Create a temp depot to store julia packages (and our custom env)
             Main = julia_helpers.init_julia()
+
+            # Set up env:
             if "JULIA_DEPOT_PATH" not in os.environ:
                 old_env = None
                 os.environ["JULIA_DEPOT_PATH"] = tmpdir
             else:
                 old_env = os.environ["JULIA_DEPOT_PATH"]
                 os.environ["JULIA_DEPOT_PATH"] = f"{tmpdir}:{os.environ['JULIA_DEPOT_PATH']}"
+            Main.eval(f'pushfirst!(DEPOT_PATH, "{julia_helpers._escape_filename(tmpdir)}")')
             test_env_name = "@pysr_test_env"
             julia_helpers.install(julia_project=test_env_name)
             Main = julia_helpers.init_julia(julia_project=test_env_name)
+
+            # Try to use env:
             Main.eval("using SymbolicRegression")
             Main.eval("using Pkg")
+            
+            # Assert we actually loaded it:
             cur_project_dir = Main.eval("splitdir(dirname(Base.active_project()))[1]")
             potential_shared_project_dirs = Main.eval("Pkg.envdir(DEPOT_PATH[1])")
             self.assertEqual(cur_project_dir, potential_shared_project_dirs)
+
+            # Clean up:
             Main.eval("pop!(DEPOT_PATH)")
             if old_env is None:
                 del os.environ["JULIA_DEPOT_PATH"]

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -15,8 +15,10 @@ class TestJuliaProject(unittest.TestCase):
             # Create a temp depot to store julia packages (and our custom env)
             Main = julia_helpers.init_julia()
             if "JULIA_DEPOT_PATH" not in os.environ:
+                old_env = None
                 os.environ["JULIA_DEPOT_PATH"] = tmpdir
             else:
+                old_env = os.environ["JULIA_DEPOT_PATH"]
                 os.environ["JULIA_DEPOT_PATH"] = f"{tmpdir}:{os.environ['JULIA_DEPOT_PATH']}"
             test_env_name = "@pysr_test_env"
             julia_helpers.install(julia_project=test_env_name)
@@ -27,3 +29,7 @@ class TestJuliaProject(unittest.TestCase):
             potential_shared_project_dirs = Main.eval("Pkg.envdir(DEPOT_PATH[1])")
             self.assertEqual(cur_project_dir, potential_shared_project_dirs)
             Main.eval("pop!(DEPOT_PATH)")
+            if old_env is None:
+                del os.environ["JULIA_DEPOT_PATH"]
+            else:
+                os.environ["JULIA_DEPOT_PATH"] = old_env

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -2,17 +2,24 @@
 
 import unittest
 from pysr import julia_helpers
+from tempfile import TemporaryDirectory
 
 
 class TestJuliaProject(unittest.TestCase):
     def test_custom_shared_env(self):
         """Test that we can use PySR in a custom shared env"""
-        test_env_name = "@pysr_test_env"
-        julia_helpers.install(julia_project=test_env_name, quiet=True)
-        Main = julia_helpers.init_julia(julia_project=test_env_name)
-        Main.eval("using SymbolicRegression")
-        Main.eval("using Pkg")
-        cur_project_dir = Main.eval("splitdir(dirname(Base.active_project()))[1]")
-        potential_shared_project_dirs = Main.eval("Pkg.envdir.(DEPOT_PATH)")
-        self.assertIn(cur_project_dir, potential_shared_project_dirs)
-        # TODO: Delete the env at the end.
+        with TemporaryDirectory() as tmpdir:
+            # Create a temp depot to store julia packages (and our custom env)
+            Main = julia_helpers.init_julia()
+            Main.eval(
+                f'pushfirst!(DEPOT_PATH, "{julia_helpers._escape_filename(tmpdir)}")'
+            )
+            test_env_name = "@pysr_test_env"
+            julia_helpers.install(julia_project=test_env_name, quiet=True)
+            Main = julia_helpers.init_julia(julia_project=test_env_name)
+            Main.eval("using SymbolicRegression")
+            Main.eval("using Pkg")
+            cur_project_dir = Main.eval("splitdir(dirname(Base.active_project()))[1]")
+            potential_shared_project_dirs = Main.eval("Pkg.envdir(DEPOT_PATH[1])")
+            self.assertEqual(cur_project_dir, potential_shared_project_dirs)
+            Main.eval("pop!(DEPOT_PATH)")


### PR DESCRIPTION
This will fix #196. If you specify an `@` in your `julia_project` string, like `julia_project="@my_project"`, then this will be designated a shared project (just as if you had specified `]activate @my_project` in the Julia REPL.

cc @mkitti 