### PR TITLE
Fix conda forge installs

### DIFF
--- a/.github/workflows/CI_conda_forge.yml
+++ b/.github/workflows/CI_conda_forge.yml
@@ -1,6 +1,6 @@
 name: conda-forge
 
-# This CI tries the conda-forge version of PYSR
+# This CI tries the conda-forge version of PySR
 
 on:
   schedule:
@@ -21,15 +21,23 @@ jobs:
       matrix:
         python-version: ['3.9']
         os: ['ubuntu-latest', 'macos-latest']
+        use-mamba: [true, false]
     
     steps:
       - uses: actions/checkout@v2
-      - name: "Set up conda"
+      - name: "Set up Conda"
         uses: conda-incubator/setup-miniconda@v2
         with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
           auto-activate-base: true
-          activate-environment: ""
+          python-version: ${{ matrix.python-version }}
+          activate-environment: test
+      - name: "Install pysr with mamba"
+        run: conda activate test && mamba install pysr
+        if: ${{ matrix.use-mamba }}
       - name: "Install pysr with conda"
-        run: conda create -n test -c conda-forge python=${{ matrix.python-version }} pysr=0.11.3
+        run: conda activate test && conda install pysr
+        if: ${{ !matrix.use-mamba }}
       - name: "Run tests"
-        run: conda activate test && python -m unittest test.test && python -m unittest test.test_env
+        run: conda activate test && python3 -m unittest test.test && python3 -m unittest test.test_env

--- a/.github/workflows/CI_conda_forge.yml
+++ b/.github/workflows/CI_conda_forge.yml
@@ -30,6 +30,6 @@ jobs:
           auto-activate-base: true
           activate-environment: ""
       - name: "Install pysr with conda"
-        run: conda create -n test -c conda-forge python=${{ matrix.python-version }} pysr
+        run: conda create -n test -c conda-forge python=${{ matrix.python-version }} pysr=0.11.2
       - name: "Run tests"
-        run: conda activate test && python3 -m unittest test.test && python3 -m unittest test.test_env
+        run: conda activate test && python -m unittest test.test && python -m unittest test.test_env

--- a/.github/workflows/CI_conda_forge.yml
+++ b/.github/workflows/CI_conda_forge.yml
@@ -22,11 +22,13 @@ jobs:
         python-version: ['3.9']
         os: ['ubuntu-latest', 'macos-latest']
         use-mamba: [true, false]
+        use-miniforge: [true, false]
     
     steps:
       - uses: actions/checkout@v2
-      - name: "Set up Conda"
+      - name: "Set up miniforge"
         uses: conda-incubator/setup-miniconda@v2
+        if: ${{ matrix.use-miniforge }}
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest
@@ -34,11 +36,20 @@ jobs:
           python-version: ${{ matrix.python-version }}
           activate-environment: test
           use-mamba: ${{ matrix.use-mamba }}
+      - name: "Set up conda"
+        uses: conda-incubator/setup-miniconda@v2
+        if: ${{ !matrix.use-miniforge }}
+        with:
+          miniconda-version: latest
+          auto-activate-base: true
+          python-version: ${{ matrix.python-version }}
+          activate-environment: test
+          use-mamba: ${{ matrix.use-mamba }}
       - name: "Install pysr with mamba"
-        run: conda activate test && mamba install pysr
+        run: conda activate test && mamba install -c conda-forge pysr
         if: ${{ matrix.use-mamba }}
       - name: "Install pysr with conda"
-        run: conda activate test && conda install pysr
+        run: conda activate test && conda install -c conda-forge pysr
         if: ${{ !matrix.use-mamba }}
       - name: "Run tests"
         run: conda activate test && python3 -m unittest test.test && python3 -m unittest test.test_env

--- a/.github/workflows/CI_conda_forge.yml
+++ b/.github/workflows/CI_conda_forge.yml
@@ -27,11 +27,10 @@ jobs:
       - name: "Set up conda"
         uses: conda-incubator/setup-miniconda@v2
         with:
-          miniconda-version: latest
-          auto-activate-base: true
           python-version: ${{ matrix.python-version }}
-          activate-environment: test
+          auto-activate-base: true
+          activate-environment: ""
       - name: "Install pysr with conda"
-        run: conda activate test && conda install -c conda-forge pysr
+        run: conda create -n test -c conda-forge pysr
       - name: "Run tests"
         run: conda activate test && python3 -m unittest test.test && python3 -m unittest test.test_env

--- a/.github/workflows/CI_conda_forge.yml
+++ b/.github/workflows/CI_conda_forge.yml
@@ -27,10 +27,9 @@ jobs:
       - name: "Set up conda"
         uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: ${{ matrix.python-version }}
           auto-activate-base: true
           activate-environment: ""
       - name: "Install pysr with conda"
-        run: conda create -n test -c conda-forge pysr
+        run: conda create -n test -c conda-forge python=${{ matrix.python-version }} pysr
       - name: "Run tests"
         run: conda activate test && python3 -m unittest test.test && python3 -m unittest test.test_env

--- a/.github/workflows/CI_conda_forge.yml
+++ b/.github/workflows/CI_conda_forge.yml
@@ -30,6 +30,6 @@ jobs:
           auto-activate-base: true
           activate-environment: ""
       - name: "Install pysr with conda"
-        run: conda create -n test -c conda-forge python=${{ matrix.python-version }} pysr=0.11.2
+        run: conda create -n test -c conda-forge python=${{ matrix.python-version }} pysr=0.11.3
       - name: "Run tests"
         run: conda activate test && python -m unittest test.test && python -m unittest test.test_env

--- a/.github/workflows/CI_conda_forge.yml
+++ b/.github/workflows/CI_conda_forge.yml
@@ -40,4 +40,4 @@ jobs:
         run: conda activate test && conda install pysr
         if: ${{ !matrix.use-mamba }}
       - name: "Run tests"
-        run: conda activate test && python3 -m unittest test.test && python3 -m unittest test.test_env
+        run: conda activate test && python3 -m unittest test.test

--- a/.github/workflows/CI_conda_forge.yml
+++ b/.github/workflows/CI_conda_forge.yml
@@ -21,7 +21,6 @@ jobs:
       matrix:
         python-version: ['3.9']
         os: ['ubuntu-latest', 'macos-latest']
-        use-mamba: [true, false]
         use-miniforge: [true, false]
     
     steps:
@@ -35,7 +34,6 @@ jobs:
           auto-activate-base: true
           python-version: ${{ matrix.python-version }}
           activate-environment: test
-          use-mamba: ${{ matrix.use-mamba }}
       - name: "Set up conda"
         uses: conda-incubator/setup-miniconda@v2
         if: ${{ !matrix.use-miniforge }}
@@ -44,12 +42,7 @@ jobs:
           auto-activate-base: true
           python-version: ${{ matrix.python-version }}
           activate-environment: test
-          use-mamba: ${{ matrix.use-mamba }}
-      - name: "Install pysr with mamba"
-        run: conda activate test && mamba install -c conda-forge pysr
-        if: ${{ matrix.use-mamba }}
       - name: "Install pysr with conda"
         run: conda activate test && conda install -c conda-forge pysr
-        if: ${{ !matrix.use-mamba }}
       - name: "Run tests"
         run: conda activate test && python3 -m unittest test.test && python3 -m unittest test.test_env

--- a/.github/workflows/CI_conda_forge.yml
+++ b/.github/workflows/CI_conda_forge.yml
@@ -21,22 +21,11 @@ jobs:
       matrix:
         python-version: ['3.9']
         os: ['ubuntu-latest', 'macos-latest']
-        use-miniforge: [true, false]
     
     steps:
       - uses: actions/checkout@v2
-      - name: "Set up miniforge"
-        uses: conda-incubator/setup-miniconda@v2
-        if: ${{ matrix.use-miniforge }}
-        with:
-          miniforge-variant: Mambaforge
-          miniforge-version: latest
-          auto-activate-base: true
-          python-version: ${{ matrix.python-version }}
-          activate-environment: test
       - name: "Set up conda"
         uses: conda-incubator/setup-miniconda@v2
-        if: ${{ !matrix.use-miniforge }}
         with:
           miniconda-version: latest
           auto-activate-base: true

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -524,7 +524,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         Project.toml file should be present from the install.
     update: bool
         Whether to automatically update Julia packages.
-        Default is `True`.
+        Default is `False`.
     output_jax_format : bool
         Whether to create a 'jax_format' column in the output,
         containing jax-callable functions and the default parameters in
@@ -700,7 +700,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         tempdir=None,
         delete_tempfiles=True,
         julia_project=None,
-        update=True,
+        update=False,
         output_jax_format=False,
         output_torch_format=False,
         extra_sympy_mappings=None,

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -523,7 +523,10 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         Default gives the Python package directory, where a
         Project.toml file should be present from the install.
     update: bool
-        Whether to automatically update Julia packages.
+        Whether to automatically update Julia packages when `fit` is called.
+        You should make sure that PySR is up-to-date itself first, as
+        the packaged Julia packages may not necessarily include all
+        updated dependencies.
         Default is `False`.
     output_jax_format : bool
         Whether to create a 'jax_format' column in the output,

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1476,7 +1476,10 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                     Main.eval(f"Pkg.resolve({io_arg})")
                 except (JuliaError, RuntimeError) as e:
                     raise ImportError(_import_error_string(julia_project)) from e
-            Main.eval("using SymbolicRegression")
+            try:
+                Main.eval("using SymbolicRegression")
+            except (JuliaError, RuntimeError) as e:
+                raise ImportError(_import_error_string(julia_project)) from e
 
             Main.plus = Main.eval("(+)")
             Main.sub = Main.eval("(-)")

--- a/pysr/version.py
+++ b/pysr/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.11.3"
+__version__ = "0.11.4"
 __symbolic_regression_jl_version__ = "0.12.2"


### PR DESCRIPTION
This will change the default behavior of PySRRegressor to **not** update the Julia packages when `.fit` is called. i.e., this will set `update=False` by default, rather than `update=True`. I think this is more in line with what a user would expect - that once they install PySR and run `pysr.install()`, all packages will remain static.

It is also causing trouble for conda-forge, since the pysr package actually includes all dependencies when first built - if any new dependency is needed, then pysr will break. This fixes #201. cc @ngam.


To update Julia packages, in pip or in conda, you may run `pysr.install()` again, or set `update=True`.


TODO:

- [x] Create test for expected behavior when a user runs `pip install -U pysr` without running `pysr.install()` a second time.
- [x] Mention in docstring for `update` kwarg that the user should make sure their pysr version is up-to-date first, before running `install()` - so there aren't any missing packages in the depot.
- [x] Bump version number.
- [ ] Create check that the `SymbolicRegression.jl` version matches what PySR expects.