### PR TITLE
Faster evaluation & perform explicit version assertion for backend

### DIFF
--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -273,6 +273,7 @@ def _load_backend(Main):
 
     _backend_version_assertion(Main)
 
+    # Load Julia package SymbolicRegression.jl
     from julia import SymbolicRegression
 
     return SymbolicRegression

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -252,3 +252,21 @@ def _load_backend(Main, julia_project):
         Main.eval("using SymbolicRegression")
     except (JuliaError, RuntimeError) as e:
         raise ImportError(_import_error_string(julia_project)) from e
+
+    try:
+        backend_version = Main.eval("string(SymbolicRegression.PACKAGE_VERSION)")
+        expected_backend_version = __symbolic_regression_jl_version__
+        if backend_version != expected_backend_version:  # pragma: no cover
+            warnings.warn(
+                f"PySR backend (SymbolicRegression.jl) version {backend_version} "
+                "does not match expected version {expected_backend_version}. "
+                "Things may break. "
+                "Please update your PySR installation."
+            )
+    except JuliaError:  # pragma: no cover
+        warnings.warn(
+            "You seem to have an outdated version of SymbolicRegression.jl. "
+            "Things may break. "
+            "Please update your PySR installation with "
+            "`python -c 'import pysr; pysr.install()'`."
+        )

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1467,18 +1467,17 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             Main.eval(
                 f'Pkg.activate("{_escape_filename(julia_project)}", shared = Bool({int(is_shared)}), {io_arg})'
             )
-            from julia.api import JuliaError
 
             if self.update:
-                _update_julia_project(Main, julia_project, is_shared, io_arg)
+                _update_julia_project(Main, is_shared, io_arg)
 
-            _load_backend(Main, julia_project)
+        SymbolicRegression = _load_backend(Main)
 
-            Main.plus = Main.eval("(+)")
-            Main.sub = Main.eval("(-)")
-            Main.mult = Main.eval("(*)")
-            Main.pow = Main.eval("(^)")
-            Main.div = Main.eval("(/)")
+        Main.plus = Main.eval("(+)")
+        Main.sub = Main.eval("(-)")
+        Main.mult = Main.eval("(*)")
+        Main.pow = Main.eval("(^)")
+        Main.div = Main.eval("(/)")
 
         # TODO(mcranmer): These functions should be part of this class.
         binary_operators, unary_operators = _maybe_create_inline_operators(
@@ -1535,7 +1534,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
 
         # Call to Julia backend.
         # See https://github.com/MilesCranmer/SymbolicRegression.jl/blob/master/src/OptionsStruct.jl
-        options = Main.Options(
+        options = SymbolicRegression.Options(
             binary_operators=Main.eval(str(tuple(binary_operators)).replace("'", "")),
             unary_operators=Main.eval(str(tuple(unary_operators)).replace("'", "")),
             bin_constraints=bin_constraints,
@@ -1608,7 +1607,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
 
         # Call to Julia backend.
         # See https://github.com/MilesCranmer/SymbolicRegression.jl/blob/master/src/SymbolicRegression.jl
-        self.raw_julia_state_ = Main.EquationSearch(
+        self.raw_julia_state_ = SymbolicRegression.EquationSearch(
             Main.X,
             Main.y,
             weights=Main.weights,

--- a/pysr/version.py
+++ b/pysr/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.11.4"
-__symbolic_regression_jl_version__ = "0.12.2"
+__version__ = "0.11.5"
+__symbolic_regression_jl_version__ = "0.12.3"

--- a/pysr/version.py
+++ b/pysr/version.py
@@ -1,2 +1,2 @@
 __version__ = "0.11.5"
-__symbolic_regression_jl_version__ = "0.12.3"
+__symbolic_regression_jl_version__ = "0.12.6"


### PR DESCRIPTION
This PR updates the backend with faster evaluation: https://github.com/MilesCranmer/SymbolicRegression.jl/pull/144

The latest version of SymbolicRegression.jl also includes a constant parameter `PACKAGE_VERSION`, which allows PySR to assert that the correct version was loaded. This will help prevent unexpected errors caused by an installation for some reason being out-of-date with what PySR expects.

This is just a warning, so it won't necessarily prevent running with a custom backend version if needed.