### PR TITLE
Speed up evaluation with `turbo` parameter

### DIFF
--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1587,7 +1587,6 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             early_stop_condition=early_stop_condition,
             seed=seed,
             deterministic=self.deterministic,
-            extend_user_operators=False,
             define_helper_functions=False,
         )
 

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1611,16 +1611,9 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             None if parallelism in ["serial", "multithreading"] else int(self.procs)
         )
 
-        # Can't pass symbol to PyJulia, so need to eval a function:
-        Main.eval(
-            "call_sr(@nospecialize args...; @nospecialize kws...)"
-            " = SymbolicRegression.EquationSearch(args...;"
-            f"parallelism=:{parallelism}, kws...)"
-        )
-
         # Call to Julia backend.
         # See https://github.com/MilesCranmer/SymbolicRegression.jl/blob/master/src/SymbolicRegression.jl
-        self.raw_julia_state_ = Main.call_sr(
+        self.raw_julia_state_ = SymbolicRegression.EquationSearch(
             Main.X,
             Main.y,
             weights=Main.weights,
@@ -1628,6 +1621,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             varMap=self.feature_names_in_.tolist(),
             options=options,
             numprocs=cprocs,
+            parallelism=parallelism,
             saved_state=self.raw_julia_state_,
             addprocs_function=cluster_manager,
         )

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1581,6 +1581,8 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             early_stop_condition=early_stop_condition,
             seed=seed,
             deterministic=self.deterministic,
+            extend_user_operators=False,
+            define_helper_functions=False,
         )
 
         # Convert data to desired precision

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -477,8 +477,9 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         faster. May be algorithmically less efficient.
         Default is `False`.
     turbo: bool
-        Whether to use LoopVectorization.jl to speed up the search
-        evaluation. Certain user-defined operators may not be supported.
+        (Experimental) Whether to use LoopVectorization.jl to speed up the
+        search evaluation. Certain operators may not be supported.
+        Does not support 16-bit precision floats.
     precision : int
         What precision to use for the data. By default this is `32`
         (float32), but you can select `64` or `16` as well, giving

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -476,6 +476,9 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         algorithm than regularized evolution, but does cycles 15%
         faster. May be algorithmically less efficient.
         Default is `False`.
+    turbo: bool
+        Whether to use LoopVectorization.jl to speed up the search
+        evaluation. Certain user-defined operators may not be supported.
     precision : int
         What precision to use for the data. By default this is `32`
         (float32), but you can select `64` or `16` as well, giving
@@ -692,6 +695,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         batching=False,
         batch_size=50,
         fast_cycle=False,
+        turbo=False,
         precision=32,
         random_state=None,
         deterministic=False,
@@ -779,6 +783,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         self.batching = batching
         self.batch_size = batch_size
         self.fast_cycle = fast_cycle
+        self.turbo = turbo
         self.precision = precision
         self.random_state = random_state
         self.deterministic = deterministic
@@ -1554,6 +1559,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             alpha=self.alpha,
             maxdepth=maxdepth,
             fast_cycle=self.fast_cycle,
+            turbo=self.turbo,
             migration=self.migration,
             hof_migration=self.hof_migration,
             fraction_replaced_hof=self.fraction_replaced_hof,

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -480,6 +480,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         (Experimental) Whether to use LoopVectorization.jl to speed up the
         search evaluation. Certain operators may not be supported.
         Does not support 16-bit precision floats.
+        Default is `False`.
     precision : int
         What precision to use for the data. By default this is `32`
         (float32), but you can select `64` or `16` as well, giving

--- a/pysr/version.py
+++ b/pysr/version.py
@@ -1,2 +1,2 @@
 __version__ = "0.11.6"
-__symbolic_regression_jl_version__ = "0.13.2"
+__symbolic_regression_jl_version__ = "0.14.0"

--- a/pysr/version.py
+++ b/pysr/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.11.5"
-__symbolic_regression_jl_version__ = "0.12.6"
+__version__ = "0.11.6"
+__symbolic_regression_jl_version__ = "0.13.1"

--- a/pysr/version.py
+++ b/pysr/version.py
@@ -1,2 +1,2 @@
 __version__ = "0.11.6"
-__symbolic_regression_jl_version__ = "0.13.1"
+__symbolic_regression_jl_version__ = "0.13.2"

--- a/test/test.py
+++ b/test/test.py
@@ -109,6 +109,8 @@ class TestPipeline(unittest.TestCase):
             verbosity=0,
             **self.default_test_kwargs,
             procs=0,
+            # Test custom operators with turbo:
+            turbo=True,
             # Test custom operators with constraints:
             nested_constraints={"square_op": {"square_op": 3}},
             constraints={"square_op": 10},

--- a/test/test.py
+++ b/test/test.py
@@ -70,12 +70,13 @@ class TestPipeline(unittest.TestCase):
         print(model.equations_)
         self.assertLessEqual(model.get_best()["loss"], 1e-4)
 
-    def test_multiprocessing(self):
+    def test_multiprocessing_turbo(self):
         y = self.X[:, 0]
         model = PySRRegressor(
             **self.default_test_kwargs,
             procs=2,
             multithreading=False,
+            turbo=True,
             early_stop_condition="stop_if(loss, complexity) = loss < 1e-4 && complexity == 1",
         )
         model.fit(self.X, y)


### PR DESCRIPTION
This updates the backend to v0.14, which has a `turbo` parameter. Turning this on uses `LoopVectorization.jl` on the operators, which can get ~30% performance improvement compared to the current evaluation mechanism.