### PR TITLE
Fixed safe operators; make progress bar print to stderr

### DIFF
--- a/pysr/version.py
+++ b/pysr/version.py
@@ -1,2 +1,2 @@
 __version__ = "0.11.8"
-__symbolic_regression_jl_version__ = "0.14.2"
+__symbolic_regression_jl_version__ = "0.14.3"

--- a/test/test.py
+++ b/test/test.py
@@ -74,6 +74,8 @@ class TestPipeline(unittest.TestCase):
         y = self.X[:, 0]
         model = PySRRegressor(
             **self.default_test_kwargs,
+            # Turbo needs to work with unsafe operators:
+            unary_operators=["sqrt"],
             procs=2,
             multithreading=False,
             turbo=True,


### PR DESCRIPTION
This lets you use `turbo=True` with operators like `sqrt`, `pow`, etc., which need to use unsafe versions inside SIMD kernels. 