### PR TITLE
Clean up dockerfile

### DIFF
--- a/.github/workflows/CI_docker.yml
+++ b/.github/workflows/CI_docker.yml
@@ -30,13 +30,13 @@ jobs:
     strategy:
       matrix:
         julia-version: ['1.8.2']
-        python-version: ['3.9.10']
+        python-version: ['3.10.8']
         os: [ubuntu-latest]
         arch: ['linux/x86_64']
 
     steps:
       - uses: actions/checkout@v3
       - name: Build docker
-        run: docker build -t pysr --build-arg ARCH=${{ matrix.arch }} --build-arg VERSION=${{ matrix.julia-version }} --build-arg PYVERSION=${{ matrix.python-version }} .
+        run: docker build --platform=${{ matrix.arch }} -t pysr --build-arg JLVERSION=${{ matrix.julia-version }} --build-arg PYVERSION=${{ matrix.python-version }} .
       - name: Test docker
         run: docker run --platform=${{ matrix.arch }} --rm pysr /bin/bash -c 'python3 -m pysr.test main && python3 -m pysr.test env'

--- a/.github/workflows/CI_docker_large_nightly.yml
+++ b/.github/workflows/CI_docker_large_nightly.yml
@@ -19,9 +19,9 @@ jobs:
       fail-fast: false
       matrix:
         julia-version: ['1.8.2']
-        python-version: ['3.9.10']
+        python-version: ['3.10.8']
         os: [ubuntu-latest]
-        arch: ['linux/x86_64', 'linux/amd64']
+        arch: ['linux/x86_64', 'linux/amd64', 'linux/arm64']
     
     steps:
       - uses: actions/checkout@v3
@@ -30,6 +30,6 @@ jobs:
         with:
           platforms: all
       - name: Build docker
-        run: docker build -t pysr --build-arg ARCH=${{ matrix.arch }} --build-arg VERSION=${{ matrix.julia-version }} --build-arg PYVERSION=${{ matrix.python-version }} .
+        run: docker build --platform=${{ matrix.arch }} -t pysr --build-arg JLVERSION=${{ matrix.julia-version }} .
       - name: Test docker
         run: docker run --platform=${{ matrix.arch }} --rm pysr /bin/bash -c 'python3 -m pysr.test main && python3 -m pysr.test env'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,17 @@
 # This builds a dockerfile containing a working copy of PySR
 # with all pre-requisites installed.
 
-ARG ARCH=linux/amd64
-ARG VERSION=latest
-ARG PKGVERSION=0.9.5
+ARG JLVERSION=latest
 
-FROM --platform=$ARCH julia:$VERSION
+FROM julia:$JLVERSION
 
 # metainformation
-LABEL org.opencontainers.image.version = $PKGVERSION
 LABEL org.opencontainers.image.authors = "Miles Cranmer"
 LABEL org.opencontainers.image.source = "https://github.com/MilesCranmer/PySR"
 LABEL org.opencontainers.image.licenses = "Apache License 2.0"
 
 # Need to use ARG after FROM, otherwise it won't get passed through.
-ARG PYVERSION=3.9.10
+ARG PYVERSION=3.10.8
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     make build-essential libssl-dev zlib1g-dev \
@@ -46,6 +43,9 @@ RUN pip3 install -r /pysr/requirements.txt
 ADD ./setup.py /pysr/setup.py
 ADD ./pysr/ /pysr/pysr/
 RUN pip3 install .
+
+# Load version information from the package:
+LABEL org.opencontainers.image.version = $(python -c "import pysr; print(pysr.__version__)")
 
 # Install Julia pre-requisites:
 RUN python3 -c 'import pysr; pysr.install()'

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ PySR uses evolutionary algorithms to search for symbolic expressions which optim
 
 | **Docs** | **colab** | **pip** | **conda** | **Stats** |
 |---|---|---|---|---|
-|[![Documentation](https://github.com/MilesCranmer/PySR/actions/workflows/docs.yml/badge.svg)](https://astroautomata.com/PySR/)|[![Colab](https://img.shields.io/badge/colab-notebook-yellow)](https://colab.research.google.com/github/MilesCranmer/PySR/blob/master/examples/pysr_demo.ipynb)|[![PyPI version](https://badge.fury.io/py/pysr.svg)](https://badge.fury.io/py/pysr)|[![Conda Version](https://img.shields.io/conda/vn/conda-forge/pysr.svg)](https://anaconda.org/conda-forge/pysr)|pip: [![Downloads](https://pepy.tech/badge/pysr)](https://badge.fury.io/py/pysr)<br>conda: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/pysr/badges/downloads.svg)](https://anaconda.org/conda-forge/pysr)|
+|[![Documentation](https://github.com/MilesCranmer/PySR/actions/workflows/docs.yml/badge.svg)](https://astroautomata.com/PySR/)|[![Colab](https://img.shields.io/badge/colab-notebook-yellow)](https://colab.research.google.com/github/MilesCranmer/PySR/blob/master/examples/pysr_demo.ipynb)|[![PyPI version](https://badge.fury.io/py/pysr.svg)](https://badge.fury.io/py/pysr)|[![Conda Version](https://img.shields.io/conda/vn/conda-forge/pysr.svg)](https://anaconda.org/conda-forge/pysr)|<div align="center">pip: [![Downloads](https://pepy.tech/badge/pysr)](https://badge.fury.io/py/pysr)<br>conda: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/pysr/badges/downloads.svg)](https://anaconda.org/conda-forge/pysr)</div>|
 
 </div>
 
@@ -263,11 +263,13 @@ the root directory of this repo:
 ```bash
 docker build --pull --rm -f "Dockerfile" -t pysr "."
 ```
-This builds an image called `pysr`. If you have issues building (for example, on Apple Silicon),
-you can emulate an architecture that works by including: `--platform linux/amd64`.
+This builds an image called `pysr`.
 You can then run this with:
 ```bash
 docker run -it --rm -v "$PWD:/data" pysr ipython
 ```
 which will link the current directory to the container's `/data` directory
 and then launch ipython.
+If you have issues building (for example, on Apple Silicon),
+you can emulate another architecture by including `--platform linux/amd64`,
+before the `build` and `run` commands.

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ docker run -it --rm -v "$PWD:/data" pysr ipython
 ```
 which will link the current directory to the container's `/data` directory
 and then launch ipython.
-If you have issues building (for example, on Apple Silicon),
+
+If you have issues building for your system's architecture,
 you can emulate another architecture by including `--platform linux/amd64`,
 before the `build` and `run` commands.

--- a/README.md
+++ b/README.md
@@ -261,9 +261,11 @@ You can also test out PySR in Docker, without
 installing it locally, by running the following command in
 the root directory of this repo:
 ```bash
-docker build --pull --rm -f "Dockerfile" -t pysr "."
+docker build -t pysr "."
 ```
-This builds an image called `pysr`.
+This builds an image called `pysr` for your system's architecture,
+which also contains IPython.
+
 You can then run this with:
 ```bash
 docker run -it --rm -v "$PWD:/data" pysr ipython


### PR DESCRIPTION
This PR:

- Now sets `org.opencontainers.image.version` based on the actual installed PySR version, rather than a user-passed arg.
- Uses whatever architecture the user has by default; though you can change it with `--platform` (rather than `--build-arg`).
- Expands testing to `arm64`.