### PR TITLE
Make Julia startup options configurable; set optimize=3

### DIFF
--- a/docs/param_groupings.yml
+++ b/docs/param_groupings.yml
@@ -82,6 +82,7 @@
   - delete_tempfiles
   - julia_project
   - update
+  - julia_kwargs
 - Exporting the Results:
   - equation_file
   - output_jax_format

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -171,6 +171,7 @@ def init_julia(julia_project=None, quiet=False, julia_kwargs=None):
         raise ImportError(_import_error())
 
     from julia.core import Julia
+
     Main = None
     try:
         jl = Julia(**julia_kwargs)

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -175,20 +175,15 @@ def init_julia(julia_project=None, quiet=False, julia_kwargs=None):
         raise ImportError(_import_error())
 
     from julia.core import Julia
-
-    Main = None
     try:
-        jl = Julia(**julia_kwargs)
-        from julia import Main as _Main
-
-        Main = _Main
+        Julia(**julia_kwargs)
     except UnsupportedPythonError:
         # Static python binary, so we turn off pre-compiled modules.
         julia_kwargs = {**julia_kwargs, "compiled_modules": False}
-        jl = Julia(**julia_kwargs)
-        from julia import Main as _Main
+        Julia(**julia_kwargs)
 
-        Main = _Main
+    from julia import Main as _Main
+    Main = _Main
 
     if julia_activated_env is None:
         julia_activated_env = processed_julia_project

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -175,6 +175,7 @@ def init_julia(julia_project=None, quiet=False, julia_kwargs=None):
         raise ImportError(_import_error())
 
     from julia.core import Julia
+
     try:
         Julia(**julia_kwargs)
     except UnsupportedPythonError:
@@ -183,6 +184,7 @@ def init_julia(julia_project=None, quiet=False, julia_kwargs=None):
         Julia(**julia_kwargs)
 
     from julia import Main as _Main
+
     Main = _Main
 
     if julia_activated_env is None:

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -143,12 +143,15 @@ def _check_for_conflicting_libraries():  # pragma: no cover
         )
 
 
-def init_julia(julia_project=None, quiet=False):
+def init_julia(julia_project=None, quiet=False, julia_kwargs=None):
     """Initialize julia binary, turning off compiled modules if needed."""
     global julia_initialized
 
     if not julia_initialized:
         _check_for_conflicting_libraries()
+
+    if julia_kwargs is None:
+        julia_kwargs = {}
 
     from julia.core import JuliaInfo, UnsupportedPythonError
 
@@ -167,16 +170,16 @@ def init_julia(julia_project=None, quiet=False):
     if not info.is_pycall_built():
         raise ImportError(_import_error())
 
+    from julia.core import Julia
     Main = None
     try:
+        jl = Julia(**julia_kwargs)
         from julia import Main as _Main
 
         Main = _Main
     except UnsupportedPythonError:
         # Static python binary, so we turn off pre-compiled modules.
-        from julia.core import Julia
-
-        jl = Julia(compiled_modules=False)
+        jl = Julia(compiled_modules=False, **julia_kwargs)
         from julia import Main as _Main
 
         Main = _Main

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -197,11 +197,12 @@ def init_julia(julia_project=None, quiet=False, julia_kwargs=None):
             set_diff = new_set - init_set
             # Remove the `compiled_modules` key, since it is not a user-specified kwarg:
             set_diff = {k: v for k, v in set_diff if k != "compiled_modules"}
-            warnings.warn(
-                "Julia has already started. The new Julia options "
-                + str(set_diff)
-                + " will be ignored."
-            )
+            if len(set_diff) > 0:
+                warnings.warn(
+                    "Julia has already started. The new Julia options "
+                    + str(set_diff)
+                    + " will be ignored."
+                )
 
     if julia_initialized:
         Main.eval("using Pkg")

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -238,7 +238,7 @@ def _backend_version_assertion(Main):
         if backend_version != expected_backend_version:  # pragma: no cover
             warnings.warn(
                 f"PySR backend (SymbolicRegression.jl) version {backend_version} "
-                "does not match expected version {expected_backend_version}. "
+                f"does not match expected version {expected_backend_version}. "
                 "Things may break. "
                 "Please update your PySR installation with "
                 "`python -c 'import pysr; pysr.install()'`."

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -190,19 +190,17 @@ def init_julia(julia_project=None, quiet=False, julia_kwargs=None):
 
     if julia_initialized and julia_kwargs_at_initialization is not None:
         # Check if the kwargs are the same as the previous initialization
-        if julia_kwargs_at_initialization != julia_kwargs:
-            # Record different kwargs:
-            init_set = set(julia_kwargs_at_initialization.items())
-            new_set = set(julia_kwargs.items())
-            set_diff = new_set - init_set
-            # Remove the `compiled_modules` key, since it is not a user-specified kwarg:
-            set_diff = {k: v for k, v in set_diff if k != "compiled_modules"}
-            if len(set_diff) > 0:
-                warnings.warn(
-                    "Julia has already started. The new Julia options "
-                    + str(set_diff)
-                    + " will be ignored."
-                )
+        init_set = set(julia_kwargs_at_initialization.items())
+        new_set = set(julia_kwargs.items())
+        set_diff = new_set - init_set
+        # Remove the `compiled_modules` key, since it is not a user-specified kwarg:
+        set_diff = {k: v for k, v in set_diff if k != "compiled_modules"}
+        if len(set_diff) > 0:
+            warnings.warn(
+                "Julia has already started. The new Julia options "
+                + str(set_diff)
+                + " will be ignored."
+            )
 
     if julia_initialized:
         Main.eval("using Pkg")

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1490,8 +1490,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         julia_kwargs = mutated_params["julia_kwargs"]
 
         # Start julia backend processes
-        if Main is None:
-            Main = init_julia(self.julia_project, julia_kwargs=julia_kwargs)
+        Main = init_julia(self.julia_project, julia_kwargs=julia_kwargs)
 
         if cluster_manager is not None:
             cluster_manager = _load_cluster_manager(cluster_manager)

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1495,20 +1495,13 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         if cluster_manager is not None:
             cluster_manager = _load_cluster_manager(cluster_manager)
 
-        if not already_ran:
-            julia_project, is_shared = _process_julia_project(self.julia_project)
-            Main.eval("using Pkg")
+        if self.update:
+            _, is_shared = _process_julia_project(self.julia_project)
             io = "devnull" if update_verbosity == 0 else "stderr"
             io_arg = (
                 f"io={io}" if is_julia_version_greater_eq(version=(1, 6, 0)) else ""
             )
-
-            Main.eval(
-                f'Pkg.activate("{_escape_filename(julia_project)}", shared = Bool({int(is_shared)}), {io_arg})'
-            )
-
-            if self.update:
-                _update_julia_project(Main, is_shared, io_arg)
+            _update_julia_project(Main, is_shared, io_arg)
 
         SymbolicRegression = _load_backend(Main)
 

--- a/pysr/version.py
+++ b/pysr/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.11.10"
+__version__ = "0.11.11"
 __symbolic_regression_jl_version__ = "0.14.4"


### PR DESCRIPTION
cc @mkitti 

I have `optimize=3`, but not sure if that's a safe default or not. I wouldn't expect any user to find `julia_kwargs` though, so I'm leaning towards choosing the fastest option as a default if I don't expect it to increase crashes.