### PR TITLE
Make docker build multi-stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,15 @@
 # This builds a dockerfile containing a working copy of PySR
 # with all pre-requisites installed.
 
+ARG JLVERSION=1.8.2
 ARG PYVERSION=3.10.8
 
+FROM julia:$JLVERSION AS jl
 FROM python:$PYVERSION
 
-# metainformation
-LABEL org.opencontainers.image.authors = "Miles Cranmer"
-LABEL org.opencontainers.image.source = "https://github.com/MilesCranmer/PySR"
-LABEL org.opencontainers.image.licenses = "Apache License 2.0"
-
-# Need to use ARG after FROM, otherwise it won't get passed through.
-ARG JLVERSION=1.8.2
-
-ENV PYVERSION $PYVERSION
-ENV JLVERSION $JLVERSION
-
-# arm64:
-# https://julialang-s3.julialang.org/bin/linux/aarch64/1.8/julia-1.8.2-linux-aarch64.tar.gz
-# amd64:
-# https://julialang-s3.julialang.org/bin/linux/x64/1.8/julia-1.8.2-linux-x86_64.tar.gz
-
-RUN export JULIA_VER=$(echo $JLVERSION | cut -d '.' -f -2) && \
-    export ARCH=$(arch | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') && \
-    if [ "$ARCH" = "amd64" ]; then \
-        export BASE_URL="https://julialang-s3.julialang.org/bin/linux/x64/$JULIA_VER" && \
-        export FULL_URL=$BASE_URL/julia-$JLVERSION-linux-x86_64.tar.gz; \
-    elif [ "$ARCH" = "arm64" ]; then \
-        export BASE_URL="https://julialang-s3.julialang.org/bin/linux/aarch64/$JULIA_VER"; \
-        export FULL_URL=$BASE_URL/julia-$JLVERSION-linux-aarch64.tar.gz; \
-    else \
-        echo "Download link for architecture ${ARCH} not found. Please add the corresponding Julia download URL to this Dockerfile." && \
-        exit 1; \
-    fi && \
-    wget -nv $FULL_URL -O julia.tar.gz && \
-    tar -xzf julia.tar.gz && \
-    rm julia.tar.gz && \
-    mv julia-$JLVERSION /opt/julia && \
-    ln -s /opt/julia/bin/julia /usr/local/bin/julia
+# Merge Julia image:
+COPY --from=jl /usr/local/julia /usr/local/julia
+ENV PATH="/usr/local/julia/bin:${PATH}"
 
 # Install IPython and other useful libraries:
 RUN pip install ipython matplotlib
@@ -56,5 +28,10 @@ RUN pip3 install .
 
 # Install Julia pre-requisites:
 RUN python3 -c 'import pysr; pysr.install()'
+
+# metainformation
+LABEL org.opencontainers.image.authors = "Miles Cranmer"
+LABEL org.opencontainers.image.source = "https://github.com/MilesCranmer/PySR"
+LABEL org.opencontainers.image.licenses = "Apache License 2.0"
 
 CMD ["ipython"]


### PR DESCRIPTION
No more manually pulling the Julia binary in a script, it turns out you can just pull from both the python and julia images, and copy the files between them!

This cleans up the dockerfile, and should make it much more robust.