### PR TITLE
Raise warning on statically-linked Python binaries

### DIFF
--- a/.github/workflows/CI_Windows.yml
+++ b/.github/workflows/CI_Windows.yml
@@ -57,9 +57,15 @@ jobs:
             python -c 'import pysr; pysr.install()'
       - name: "Run tests"
         run: python -m pysr.test main
+        env:
+          JULIA_CHECK_BOUNDS: yes
       - name: "Install Torch"
         run: pip install torch # (optional import)
       - name: "Run Torch tests"
         run: python -m pysr.test torch
+        env:
+          JULIA_CHECK_BOUNDS: yes
       - name: "Run custom env tests"
         run: python -m pysr.test env
+        env:
+          JULIA_CHECK_BOUNDS: yes

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -181,7 +181,9 @@ def init_julia(julia_project=None, quiet=False, julia_kwargs=None):
     except UnsupportedPythonError:
         # Static python binary, so we turn off pre-compiled modules.
         warnings.warn(
-            "You are using a statically-linked Python binary. The first run of PySR will be slower, as all dependencies need to be compiled. Switch to a dynamically-linked version of Python to have a faster startup time."
+            "You are using a statically-linked Python binary. "
+            "The first run of PySR will be slower, as all dependencies need to be compiled. "
+            "Switch to a dynamically-linked version of Python to have a faster startup time."
         )
         julia_kwargs = {**julia_kwargs, "compiled_modules": False}
         Julia(**julia_kwargs)

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -157,6 +157,9 @@ def init_julia(julia_project=None, quiet=False, julia_kwargs=None):
     if julia_kwargs is None:
         julia_kwargs = {"optimize": 3}
 
+    if "check_bounds" not in julia_kwargs and "JULIA_CHECK_BOUNDS" in os.environ:
+        julia_kwargs["check_bounds"] = os.environ["JULIA_CHECK_BOUNDS"]
+
     from julia.core import JuliaInfo, UnsupportedPythonError
 
     _julia_version_assertion()

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -180,6 +180,9 @@ def init_julia(julia_project=None, quiet=False, julia_kwargs=None):
         Julia(**julia_kwargs)
     except UnsupportedPythonError:
         # Static python binary, so we turn off pre-compiled modules.
+        warnings.warn(
+            "You are using a statically-linked Python binary. The first run of PySR will be slower, as all dependencies need to be compiled. Switch to a dynamically-linked version of Python to have a faster startup time."
+        )
         julia_kwargs = {**julia_kwargs, "compiled_modules": False}
         Julia(**julia_kwargs)
 

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -183,7 +183,7 @@ def init_julia(julia_project=None, quiet=False, julia_kwargs=None):
         warnings.warn(
             "You are using a statically-linked Python binary. "
             "The first run of PySR will be slower, as all dependencies need to be compiled. "
-            "Switch to a dynamically-linked version of Python to have a faster startup time."
+            "Switch to a dynamically-linked version of Python (like pyenv) to have a faster startup time."
         )
         julia_kwargs = {**julia_kwargs, "compiled_modules": False}
         Julia(**julia_kwargs)

--- a/pysr/version.py
+++ b/pysr/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.11.11"
+__version__ = "0.11.12"
 __symbolic_regression_jl_version__ = "0.14.4"


### PR DESCRIPTION
Time-to-first-search is very slow on statically-linked versions of Python (such as packaged with conda), as precompiled code cannot be used, so things are compiled from scratch. I think this adds some friction to the user experience, so this PR introduces a warning that recommends the user try `pyenv` if startup time is important.

When https://github.com/JuliaPy/pyjulia/issues/496 is solved, this warning is no longer needed.

See https://github.com/conda-forge/python-feedstock/issues/222 for the discussion on the conda page.