### PR TITLE
Create interactive API reference page

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: 3.9
           cache: pip
       - name: "Install packages for docs building"
-        run: pip install mkdocs-material mkdocs-autorefs 'mkdocstrings[python]' docstring_parser
+        run: pip install -r docs/requirements.txt
       - name: "Install PySR"
         run: pip install -e .
       - name: "Build API docs"

--- a/docs/interactive-docs.md
+++ b/docs/interactive-docs.md
@@ -1,0 +1,8 @@
+# Interactive Reference ⭐
+
+<!-- Display content from `astroautomata.com/pysr_interactive` -->
+
+The following docs are interactive, and, based on your selections,
+will create a snippet of Python code at the bottom which you can execute locally.
+
+<embed src="https://astroautomata.com/pysr_interactive" width="100%" height="2000px" />

--- a/docs/interactive-docs.md
+++ b/docs/interactive-docs.md
@@ -4,5 +4,7 @@
 
 The following docs are interactive, and, based on your selections,
 will create a snippet of Python code at the bottom which you can execute locally.
+Note that this is an incomplete list of options; for the full list,
+see the [API Reference](api.md).
 
 <embed src="https://astroautomata.com/pysr_interactive" width="100%" height="2000px" />

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+mkdocs-material
+mkdocs-autorefs
+mkdocstrings[python]
+docstring_parser

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,7 @@ nav:
     - api.md
     - api-advanced.md
   - backend.md
+  - interactive-docs.md
 
 extra:
   homepage: https://astroautomata.com/PySR


### PR DESCRIPTION
Essentially looks like this:

https://user-images.githubusercontent.com/7593028/212496152-4f315e8f-240a-4ca7-a2ac-906e551d2682.mov

but with added docs-on-hover for each option. 

Will be a new page in the docs dedicated to the interactive version.
