### PR TITLE
Allow user to specify full objective functions

### DIFF
--- a/docs/param_groupings.yml
+++ b/docs/param_groupings.yml
@@ -11,6 +11,7 @@
     - ncyclesperiteration
   - The Objective:
     - loss
+    - full_objective
     - model_selection
   - Working with Complexities:
     - parsimony

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -762,7 +762,6 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         julia_kwargs=None,
         **kwargs,
     ):
-
         # Hyperparameters
         # - Model search parameters
         self.model_selection = model_selection
@@ -2123,7 +2122,6 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         equation_file_contents = copy.deepcopy(self.equation_file_contents_)
 
         for output in equation_file_contents:
-
             scores = []
             lastMSE = None
             lastComplexity = 0

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1247,7 +1247,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             )
 
         if self.loss is not None and self.full_objective is not None:
-            raise ValueError("You cannot set both `loss` and `objective`.")
+            raise ValueError("You cannot set both `loss` and `full_objective`.")
 
         # NotImplementedError - Values that could be supported at a later time
         if self.optimizer_algorithm not in VALID_OPTIMIZER_ALGORITHMS:

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -341,7 +341,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         of loss function or regularizations. The default `full_objective`
         used in SymbolicRegression.jl is roughly equal to:
         ```julia
-        function eval_loss(tree, dataset::Dataset{T}, options) where T
+        function eval_loss(tree, dataset::Dataset{T}, options)::T where T
             prediction, flag = eval_tree_array(tree, dataset.X, options)
             if !flag
                 return T(Inf)
@@ -350,6 +350,9 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         end
         ```
         where the example elementwise loss is mean-squared error.
+        You may pass a function with the same arguments as this (note
+        that the name of the function doesn't matter). Here,
+        both `prediction` and `dataset.y` are 1D arrays of length `dataset.n`.
         Default is `None`.
     complexity_of_operators : dict[str, float]
         If you would like to use a complexity other than 1 for an

--- a/pysr/test/test.py
+++ b/pysr/test/test.py
@@ -87,11 +87,12 @@ class TestPipeline(unittest.TestCase):
         print(model.equations_)
         self.assertLessEqual(model.equations_.iloc[-1]["loss"], 1e-4)
 
-    def test_high_precision_search(self):
+    def test_high_precision_search_custom_loss(self):
         y = 1.23456789 * self.X[:, 0]
         model = PySRRegressor(
             **self.default_test_kwargs,
             early_stop_condition="stop_if(loss, complexity) = loss < 1e-4 && complexity == 3",
+            loss="my_loss(prediction, target) = (prediction - target)^2",
             precision=64,
             parsimony=0.01,
             warm_start=True,

--- a/pysr/test/test.py
+++ b/pysr/test/test.py
@@ -243,7 +243,6 @@ class TestPipeline(unittest.TestCase):
         regressor.fit(self.X, y)
 
     def test_noisy(self):
-
         y = self.X[:, [0, 1]] ** 2 + self.rstate.randn(self.X.shape[0], 1) * 0.05
         model = PySRRegressor(
             # Test that passing a single operator works:
@@ -677,7 +676,7 @@ class TestMiscellaneous(unittest.TestCase):
 
         check_generator = check_estimator(model, generate_only=True)
         exception_messages = []
-        for (_, check) in check_generator:
+        for _, check in check_generator:
             try:
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore")

--- a/pysr/test/test.py
+++ b/pysr/test/test.py
@@ -72,8 +72,10 @@ class TestPipeline(unittest.TestCase):
         print(model.equations_)
         self.assertLessEqual(model.get_best()["loss"], 1e-4)
 
-    def test_multiprocessing_turbo(self):
+    def test_multiprocessing_turbo_custom_objective(self):
+        rstate = np.random.RandomState(0)
         y = self.X[:, 0]
+        y += rstate.randn(*y.shape) * 1e-4
         model = PySRRegressor(
             **self.default_test_kwargs,
             # Turbo needs to work with unsafe operators:
@@ -81,11 +83,21 @@ class TestPipeline(unittest.TestCase):
             procs=2,
             multithreading=False,
             turbo=True,
-            early_stop_condition="stop_if(loss, complexity) = loss < 1e-4 && complexity == 1",
+            early_stop_condition="stop_if(loss, complexity) = loss < 1e-10 && complexity == 1",
+            full_objective="""
+            function my_objective(tree::Node{T}, dataset::Dataset{T}, options::Options) where T
+                prediction, flag = eval_tree_array(tree, dataset.X, options)
+                !flag && return T(Inf)
+                abs3(x) = abs(x) ^ 3
+                return sum(abs3, prediction .- dataset.y) / length(prediction)
+            end
+            """,
         )
         model.fit(self.X, y)
         print(model.equations_)
-        self.assertLessEqual(model.equations_.iloc[-1]["loss"], 1e-4)
+        best_loss = model.equations_.iloc[-1]["loss"]
+        self.assertLessEqual(best_loss, 1e-10)
+        self.assertGreaterEqual(best_loss, 0.0)
 
     def test_high_precision_search_custom_loss(self):
         y = 1.23456789 * self.X[:, 0]

--- a/pysr/version.py
+++ b/pysr/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.11.17"
+__version__ = "0.11.18"
 __symbolic_regression_jl_version__ = "0.15.3"


### PR DESCRIPTION
Right now, a user can only specify a custom elementwise loss function. This change allows the user to customize the entire objective function, including:

- Correlation or whole array-based losses (fixes https://github.com/MilesCranmer/PySR/issues/182, https://github.com/MilesCranmer/PySR/discussions/270, https://github.com/MilesCranmer/PySR/discussions/256).
- Objectives that include symbolic manipulation (fixes https://github.com/MilesCranmer/PySR/discussions/275). See below for a cool example.
- Objectives that have symbolic-based regularizations, like soft penalties on symbolic constraints, rather than hard penalties.


Here's a cool example that let's you fix a symbolic form of an expression, as a rational function (i.e., $P(X)/Q(X)$ for polynomials $P$ and $Q$).

```python
objective = """
function my_custom_objective(tree, dataset::Dataset{T}, options) where {T<:Real}
    # Require root node to be binary, so we can split it,
    # otherwise return a large loss:
    tree.degree != 2 && return T(10000)

    left = tree.l
    right = tree.r

    # Evaluate numerator:
    l_prediction, l_flag = eval_tree_array(left, dataset.X, options)
    !l_flag && return T(10000)

    # Evaluate denominator:
    r_prediction, r_flag = eval_tree_array(right, dataset.X, options)
    !r_flag && return T(10000)

    # Impose functional form:
    prediction = l_prediction ./ r_prediction

    return sum((prediction .- dataset.y) .^ 2) / dataset.n
end
"""

model = PySRRegressor(
    binary_operators=["*", "+", "-"],
    full_objective=objective
)
```

Note that the output equations will need to be parsed/interpreted manually, because the default printing scheme doesn't know about this custom symbolic manipulation. (The root node of `((x0 + 3.2) - 0.5)` is `-`).