### PR TITLE
Complex-valued expressions

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -284,7 +284,41 @@ You can get the sympy version of the best equation with:
 model.sympy()
 ```
 
-## 8. Additional features
+## 8. Complex numbers
+
+PySR can also search for complex-valued expressions. Simply pass
+data with a complex datatype (e.g., `np.complex128`),
+and PySR will automatically search for complex-valued expressions:
+
+```python
+import numpy as np
+
+X = np.random.randn(100, 1) + 1j * np.random.randn(100, 1)
+y = (1 + 2j) * np.cos(X[:, 0] * (0.5 - 0.2j))
+
+model = PySRRegressor(
+    binary_operators=["+", "-", "*"], unary_operators=["cos"], niterations=100,
+)
+
+model.fit(X, y)
+```
+
+You can see that all of the learned constants are now complex numbers.
+We can get the sympy version of the best equation with:
+
+```python
+model.sympy()
+```
+
+We can also make predictions normally, by passing complex data:
+
+```python
+model.predict(X, -1)
+```
+
+to make predictions with the most accurate expression.
+
+## 9. Additional features
 
 For the many other features available in PySR, please
 read the [Options section](options.md).

--- a/pysr/__init__.py
+++ b/pysr/__init__.py
@@ -1,3 +1,4 @@
+from . import sklearn_monkeypatch
 from .version import __version__
 from .sr import (
     pysr,

--- a/pysr/sklearn_monkeypatch.py
+++ b/pysr/sklearn_monkeypatch.py
@@ -1,0 +1,13 @@
+# Here, we monkey patch scikit-learn until this
+# issue is fixed: https://github.com/scikit-learn/scikit-learn/issues/25922
+from sklearn.utils import validation
+
+
+def _ensure_no_complex_data(*args, **kwargs):
+    ...
+
+
+try:
+    validation._ensure_no_complex_data = _ensure_no_complex_data
+except AttributeError:
+    ...

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -2020,13 +2020,14 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         regexp_im = re.compile(r"\b(\d+\.\d+)im\b")
         regexp_im_sci = re.compile(r"\b(\d+\.\d+)[eEfF]([+-]?\d+)im\b")
         regexp_sci = re.compile(r"\b(\d+\.\d+)[eEfF]([+-]?\d+)\b")
+        apply_regexp_im = lambda x: regexp_im.sub(r"\1j", x)
+        apply_regexp_im_sci = lambda x: regexp_im_sci.sub(r"\1e\2j", x)
+        apply_regexp_sci = lambda x: regexp_sci.sub(r"\1e\2", x)
 
         def _replace_im(df):
-            df["equation"] = df["equation"].apply(lambda x: regexp_im.sub(r"\1j", x))
             df["equation"] = df["equation"].apply(
-                lambda x: regexp_im_sci.sub(r"\1e\2j", x)
+                lambda x: apply_regexp_sci(apply_regexp_im_sci(apply_regexp_im(x)))
             )
-            df["equation"] = df["equation"].apply(lambda x: regexp_sci.sub(r"\1e\2", x))
 
         try:
             if self.nout_ > 1:

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1622,14 +1622,12 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
 
         # Convert data to desired precision
         test_X = np.array(X)
-        is_real = np.issubdtype(test_X.dtype, np.floating)
         is_complex = np.issubdtype(test_X.dtype, np.complexfloating)
+        is_real = not is_complex
         if is_real:
             np_dtype = {16: np.float16, 32: np.float32, 64: np.float64}[self.precision]
-        elif is_complex:
-            np_dtype = {32: np.complex64, 64: np.complex128}[self.precision]
         else:
-            np_dtype = None
+            np_dtype = {32: np.complex64, 64: np.complex128}[self.precision]
 
         # This converts the data into a Julia array:
         Main.X = np.array(X, dtype=np_dtype).T

--- a/pysr/test/test.py
+++ b/pysr/test/test.py
@@ -181,6 +181,20 @@ class TestPipeline(unittest.TestCase):
             print("Model equations: ", model.sympy()[1])
             print("True equation: x1^2")
 
+    def test_complex_equations_anonymous_stop(self):
+        X = self.rstate.randn(100, 3) + 1j * self.rstate.randn(100, 3)
+        y = (2 + 1j) * np.cos(X[:, 0] * (0.5 - 0.3j))
+        model = PySRRegressor(
+            binary_operators=["+", "-", "*"],
+            unary_operators=["cos"],
+            **self.default_test_kwargs,
+            early_stop_condition="(loss, complexity) -> loss <= 1e-4 && complexity <= 6",
+        )
+        model.fit(X, y)
+        test_y = model.predict(X)
+        self.assertTrue(np.issubdtype(test_y.dtype, np.complexfloating))
+        self.assertLessEqual(np.average(np.abs(test_y - y) ** 2), 1e-4)
+
     def test_empty_operators_single_input_warm_start(self):
         X = self.rstate.randn(100, 1)
         y = X[:, 0] + 3.0

--- a/pysr/test/test.py
+++ b/pysr/test/test.py
@@ -244,7 +244,6 @@ class TestPipeline(unittest.TestCase):
         regressor.fit(self.X, y)
 
     def test_noisy(self):
-
         y = self.X[:, [0, 1]] ** 2 + self.rstate.randn(self.X.shape[0], 1) * 0.05
         model = PySRRegressor(
             # Test that passing a single operator works:
@@ -678,7 +677,7 @@ class TestMiscellaneous(unittest.TestCase):
 
         check_generator = check_estimator(model, generate_only=True)
         exception_messages = []
-        for (_, check) in check_generator:
+        for _, check in check_generator:
             try:
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore")

--- a/pysr/version.py
+++ b/pysr/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.11.17"
-__symbolic_regression_jl_version__ = "0.15.3"
+__version__ = "0.12.0"
+__symbolic_regression_jl_version__ = "0.16.0"

--- a/pysr/version.py
+++ b/pysr/version.py
@@ -1,2 +1,2 @@
 __version__ = "0.12.0"
-__symbolic_regression_jl_version__ = "0.16.0"
+__symbolic_regression_jl_version__ = "0.16.1"


### PR DESCRIPTION
This enables PySR to search for complex-valued expressions. Now, if you pass complex data, it will automatically search for complex expressions.

Specifying `precision=32` (default) will use `complex64` and `precision=64` will use `complex128`.

For example:

```python
import numpy as np
from pysr import PySRRegressor

X = np.random.randn(100, 3) + 1j * np.random.randn(100, 3)
y = (2 + 1j) * np.cos(X[:, 0] * (0.5 - 0.3j))

model = PySRRegressor(binary_operators=["+", "-", "*"], unary_operators=["cos"])
model.fit(X, y)
```

we can look at the best expression with:

```python
model.sympy()
```

this gives me:

```
(2.0000386 + 1.0000093*I)*cos(x0*(0.49999392 - 0.2999942*I))
```

---

The one downside of this change is I have to monkey patch scikit-learn at runtime, because their `BaseEstimator` class includes an explicit check that the input data does *not* include complex numbers. Until this issue: https://github.com/scikit-learn/scikit-learn/issues/25922 is fixed, this monkey patch is required. So, whenever you import `pysr`, know that other scikit-learn objects will also skip doing this complex number check.

---

TODO:

- [x] Add complex numbers example to docs