### PR TITLE
Include Python and Julia version in PySR env

### DIFF
--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -124,7 +124,7 @@ def _process_julia_project(julia_project):
         )
         python_version = ".".join(map(str, sys.version_info[:2]))
         processed_julia_project = (
-            f"pysr-{__version__}" f"-py-{python_version}" f"-jl-{julia_version}"
+            f"pysr-{__version__}-py-{python_version}-jl-{julia_version}"
         )
     elif julia_project[0] == "@":
         is_shared = True

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -122,9 +122,8 @@ def _process_julia_project(julia_project):
         julia_version = ".".join(
             map(str, (juliainfo.version_major, juliainfo.version_minor))
         )
-        python_version = ".".join(map(str, sys.version_info[:2]))
         processed_julia_project = (
-            f"pysr-{__version__}-py-{python_version}-jl-{julia_version}"
+            f"pysr-{__version__}-jl-{julia_version}"
         )
     elif julia_project[0] == "@":
         is_shared = True

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -124,9 +124,7 @@ def _process_julia_project(julia_project):
         )
         python_version = ".".join(map(str, sys.version_info[:2]))
         processed_julia_project = (
-            f"pysr-{__version__}"
-            f"-py-{python_version}"
-            f"-jl-{julia_version}"
+            f"pysr-{__version__}" f"-py-{python_version}" f"-jl-{julia_version}"
         )
     elif julia_project[0] == "@":
         is_shared = True

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -122,9 +122,7 @@ def _process_julia_project(julia_project):
         julia_version = ".".join(
             map(str, (juliainfo.version_major, juliainfo.version_minor))
         )
-        processed_julia_project = (
-            f"pysr-{__version__}-jl-{julia_version}"
-        )
+        processed_julia_project = f"pysr-{__version__}-jl-{julia_version}"
     elif julia_project[0] == "@":
         is_shared = True
         processed_julia_project = julia_project[1:]

--- a/pysr/julia_helpers.py
+++ b/pysr/julia_helpers.py
@@ -118,7 +118,16 @@ def _import_error():
 def _process_julia_project(julia_project):
     if julia_project is None:
         is_shared = True
-        processed_julia_project = f"pysr-{__version__}"
+        juliainfo = _load_juliainfo()
+        julia_version = ".".join(
+            map(str, (juliainfo.version_major, juliainfo.version_minor))
+        )
+        python_version = ".".join(map(str, sys.version_info[:2]))
+        processed_julia_project = (
+            f"pysr-{__version__}"
+            f"-py-{python_version}"
+            f"-jl-{julia_version}"
+        )
     elif julia_project[0] == "@":
         is_shared = True
         processed_julia_project = julia_project[1:]


### PR DESCRIPTION
Rather than `@pysr-0.14.2` as the Julia environment, this would make it `@pysr-0.14.2-py-3.11-jl-1.9`. Thus the user would need to re-install for each combination of Python and Julia they wish to use PySR with. This is to prevent some of the issues noted in #257

cc @mkitti @ngam I wonder if this would pose an issue for conda at all? If I install a different `julia` version in conda, it would also trigger a new PySR install, right?