### PR TITLE
Ensure files are read as utf-8 on all operating systems

### DIFF
--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -2189,7 +2189,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                     cur_filename = str(self.equation_file_) + f".out{i}" + ".bkup"
                     if not os.path.exists(cur_filename):
                         cur_filename = str(self.equation_file_) + f".out{i}"
-                    with open(cur_filename, "r") as f:
+                    with open(cur_filename, "r", encoding="utf-8") as f:
                         buf = f.read()
                     buf = _preprocess_julia_floats(buf)
 
@@ -2200,7 +2200,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
                 filename = str(self.equation_file_) + ".bkup"
                 if not os.path.exists(filename):
                     filename = str(self.equation_file_)
-                with open(filename, "r") as f:
+                with open(filename, "r", encoding="utf-8") as f:
                     buf = f.read()
                 buf = _preprocess_julia_floats(buf)
                 all_outputs = [self._postprocess_dataframe(pd.read_csv(StringIO(buf)))]

--- a/pysr/version.py
+++ b/pysr/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.15.1"
+__version__ = "0.15.2"
 __symbolic_regression_jl_version__ = "0.21.3"


### PR DESCRIPTION
Fixes #395.

The default Julia encoding is UTF-8, so the writing seems fine.

However, apparently Python has different encodings for _reading_ on different architectures, which is why it can break sometimes. The fix is to always assume UTF-8 in reading the equation file.