### PR TITLE
Warn user when using power laws

### DIFF
--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -104,6 +104,16 @@ def _process_constraints(binary_operators, unary_operators, constraints):
             constraints[op] = -1
     for op in binary_operators:
         if op not in constraints:
+            if op in ["^", "pow"]:
+                # Warn user that they should set up constraints
+                warnings.warn(
+                    "You are using the `^` operator, but have not set up `constraints` for it. "
+                    "This may lead to overly complex expressions. "
+                    "One typical constraint is to use `constraints={..., '^': (-1, 1)}`, which "
+                    "will allow arbitrary-complexity base (-1) but only powers such as "
+                    "a constant or variable (1). "
+                    "For more tips, please see https://astroautomata.com/PySR/tuning/"
+                )
             constraints[op] = (-1, -1)
         if op in ["plus", "sub", "+", "-"]:
             if constraints[op][0] != constraints[op][1]:

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1274,14 +1274,13 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         # Ensure instance parameters are allowable values:
         if self.tournament_selection_n > self.population_size:
             raise ValueError(
-                "tournament_selection_n parameter must be smaller than population_size."
+                "`tournament_selection_n` parameter must be smaller than `population_size`."
             )
 
         if self.maxsize > 40:
             warnings.warn(
                 "Note: Using a large maxsize for the equation search will be "
-                "exponentially slower and use significant memory. You should consider "
-                "turning `use_frequency` to False, and perhaps use `warmup_maxsize_by`."
+                "exponentially slower and use significant memory."
             )
         elif self.maxsize < 7:
             raise ValueError("PySR requires a maxsize of at least 7")

--- a/pysr/test/test.py
+++ b/pysr/test/test.py
@@ -20,6 +20,7 @@ from ..sr import (
     _csv_filename_to_pkl_filename,
     idx_model_selection,
     _check_assertions,
+    _process_constraints,
 )
 from ..export_latex import to_latex
 
@@ -552,6 +553,11 @@ class TestMiscellaneous(unittest.TestCase):
 
         # The correct value should be set:
         self.assertEqual(model.fraction_replaced, 0.2)
+
+    def test_power_law_warning(self):
+        """Ensure that a warning is given for a power law operator."""
+        with self.assertWarns(UserWarning):
+            _process_constraints(["^"], [], {})
 
     def test_size_warning(self):
         """Ensure that a warning is given for a large input size."""

--- a/pysr/version.py
+++ b/pysr/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.15.3"
+__version__ = "0.15.4"
 __symbolic_regression_jl_version__ = "0.21.5"


### PR DESCRIPTION
It is a common mistake users seem to make that they allow for power laws without setting any constraints on complexity of their arguments. This change will trigger a warning when this happens, and also point the user to the docs for more information.