### PR TITLE
[WIP] experimental way to access expression methods

### DIFF
--- a/pysr/__init__.py
+++ b/pysr/__init__.py
@@ -4,6 +4,7 @@ from .export_jax import sympy2jax
 from .export_torch import sympy2torch
 from .feynman_problems import FeynmanProblem, Problem
 from .julia_helpers import install
+from .pysr_expression import Expression
 from .sr import PySRRegressor
 from .version import __version__
 
@@ -15,6 +16,7 @@ __all__ = [
     "Problem",
     "install",
     "PySRRegressor",
+    "Expression",
     "best",
     "best_callable",
     "best_row",

--- a/pysr/pysr_expression.py
+++ b/pysr/pysr_expression.py
@@ -1,0 +1,75 @@
+from numbers import Number
+from typing import List, Optional
+
+from .sr import PySRRegressor
+
+
+class Expression:
+    """A wrapper around `SymbolicRegression.Node`"""
+
+    def __init__(
+        self,
+        equation,
+        *,
+        model: PySRRegressor = None,
+        options=None,
+        variable_names: Optional[List[str]] = None,
+    ):
+        super().__init__()
+        # exactly one of model and options is None:
+        assert (model is None) != (
+            options is None
+        ), "Pass exactly one of model and options"
+
+        self.equation = equation
+        self.options = model.sr_options_ if options is None else options
+        self.variable_names = (
+            variable_names
+            if variable_names is not None
+            else (model.feature_names_in_ if model is not None else None)
+        )
+
+        from julia import Main, SymbolicRegression
+
+        self.julia_ = Main
+        self.backend_ = SymbolicRegression
+
+    @classmethod
+    def from_string(
+        cls,
+        s: str,
+        *,
+        model: PySRRegressor = None,
+        options=None,
+        variable_names: Optional[List[str]] = None,
+    ):
+        self = cls(None, model=model, options=options, variable_names=variable_names)
+
+        for i, variable in enumerate(self.variable_names):
+            self.julia_.eval(f"{variable} = Node(feature={i + 1})")
+
+        self.julia_.last_options = self.options
+        self.julia_.eval("SymbolicRegression.@extend_operators last_options")
+
+        equation = self.julia_.eval(s)
+
+        if isinstance(equation, Number):
+            equation = self.julia_.eval(f"Node(val={equation})")
+
+        self.equation = equation
+
+        return self
+
+    def __repr__(self):
+        variable_names = (
+            list(self.variable_names) if self.variable_names is not None else None
+        )
+        return self.backend_.string_tree(
+            self.equation, self.options, variable_names=variable_names
+        )
+
+    def __call__(self, X):
+        return self.equation(X.T, self.options)
+
+    def compute_complexity(self) -> int:
+        return int(self.backend_.compute_complexity(self.equation, self.options))


### PR DESCRIPTION
This creates an `Expression` class that wraps `SymbolicRegression.Node`. This would make it easier to access various internal methods of `SymbolicRegression`.

However, this is very experimental and I'm not sure what the best way forward is. There are a few options:

1. Have this wrapper class and forward methods.
2. Attach a few methods to `PySRRegressor`. Cleaner because we don't need the user to pass `model` and `variable_names` manually. However I'm worried the number of methods to `PySRRegressor` could explode.....
3. Only create a method to convert from string to `Node`. Then, expect the user to call `SymbolicRegression.<method>` themselves, using `model.sr_options_` when needed.

I think (3) would make the maintenance job the easiest was we wouldn't have to write a Python equivalent for everything..... However, one downside is that the printing functionality for manually-created expressions does not seem to use `variable_names`. Maybe for that we need to set `define_helper_functions=True` when creating the `Options`.


Fixes #339 and probably a few other issues which want an easier way to access backend internals.

