### PR TITLE
Add missing SymPy maps for `logical_or`, `logical_and`, and `relu`

### DIFF
--- a/pysr/export_sympy.py
+++ b/pysr/export_sympy.py
@@ -47,6 +47,8 @@ sympy_mappings = {
     "ceil": sympy.ceiling,
     "sign": sympy.sign,
     "gamma": sympy.gamma,
+    "logical_or": lambda x, y: sympy.Piecewise((1.0, 0.0), ((x > 0) | (y > 0), True)),
+    "logical_and": lambda x, y: sympy.Piecewise((1.0, 0.0), ((x > 0) & (y > 0), True)),
 }
 
 


### PR DESCRIPTION
Thanks to @j-thib for pointing this out, I didn't realize the SymPy maps were not built-in.