### PR TITLE
Update Python versions in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -164,8 +164,8 @@ jobs:
       - name: "Install PySR and all dependencies"
         run: |
             python -m pip install --upgrade pip
-            pip install -r requirements.txt
-            pip install mypy jax jaxlib torch
+            python -m pip install -r requirements.txt
+            python -m pip install mypy jax jaxlib torch
             python setup.py install
       - name: "Run mypy"
-        run: mypy --install-types --non-interactive pysr
+        run: python -m mypy --install-types --non-interactive pysr

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         julia-version: ['1.9']
-        python-version: ['3.10']
+        python-version: ['3.12']
         os: [ubuntu-latest]
 
     steps:
@@ -94,7 +94,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.12']
         os: ['ubuntu-latest']
 
     steps:
@@ -152,7 +152,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.12']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/CI_Windows.yml
+++ b/.github/workflows/CI_Windows.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         julia-version: ['1.9']
-        python-version: ['3.10']
+        python-version: ['3.12']
         os: [windows-latest]
 
     steps:

--- a/.github/workflows/CI_conda_forge.yml
+++ b/.github/workflows/CI_conda_forge.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.10', '3.11', '3.12']
         os: ['ubuntu-latest', 'macos-latest']
         use-mamba: [true, false]
 

--- a/.github/workflows/CI_docker_large_nightly.yml
+++ b/.github/workflows/CI_docker_large_nightly.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         julia-version: ['1.6', '1.9']
-        python-version: ['3.10']
+        python-version: ['3.12']
         os: [ubuntu-latest]
         arch: ['linux/amd64', 'linux/arm64']
 

--- a/.github/workflows/CI_large_nightly.yml
+++ b/.github/workflows/CI_large_nightly.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         julia-version: ['1.6', '1.8', '1.9']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/.github/workflows/CI_mac.yml
+++ b/.github/workflows/CI_mac.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         julia-version: ['1.9']
-        python-version: ['3.10']
+        python-version: ['3.12']
         os: [macos-latest]
 
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: "Set up Python"
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
           cache: pip
       - name: "Install packages for docs building"
         run: pip install -r docs/requirements.txt

--- a/.github/workflows/pypi_deploy.yml
+++ b/.github/workflows/pypi_deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: "Set up Python"
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10.8
+          python-version: 3.11
       - name: "Install building tools"
         run: pip install wheel
       - name: "Build package"

--- a/.github/workflows/update_backend.yml
+++ b/.github/workflows/update_backend.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
           cache: pip
 
       - name: "Install PySR"


### PR DESCRIPTION
Seems like Python 3.12 is stable enough to add to the testing now.

Once https://github.com/conda-forge/pysr-feedstock/pull/106 is finished we should be able to merge this.