### PR TITLE
Added "min" and "max" sympy mapping

### DIFF
--- a/pysr/export_sympy.py
+++ b/pysr/export_sympy.py
@@ -48,7 +48,7 @@ sympy_mappings = {
     "sign": sympy.sign,
     "gamma": sympy.gamma,
     "max": lambda x, y: sympy.Piecewise((y, x < y), (x, True)),
-    "min" : lambda x, y: sympy.Piecewise((x, x < y), (y, True)),
+    "min": lambda x, y: sympy.Piecewise((x, x < y), (y, True)),
 }
 
 

--- a/pysr/export_sympy.py
+++ b/pysr/export_sympy.py
@@ -47,6 +47,8 @@ sympy_mappings = {
     "ceil": sympy.ceiling,
     "sign": sympy.sign,
     "gamma": sympy.gamma,
+    "max": lambda x, y: sympy.Piecewise((y, x < y), (x, True)),
+    "min" : lambda x, y: sympy.Piecewise((x, x < y), (y, True)),
 }
 
 


### PR DESCRIPTION
To overcome the sympy bug while using Min/Max operators as discussed under this issue: https://github.com/MilesCranmer/PySR/issues/183

Fixes #183 