### PR TITLE
Added "round" operator in the Sympy mappings

### DIFF
--- a/pysr/export_sympy.py
+++ b/pysr/export_sympy.py
@@ -49,6 +49,7 @@ sympy_mappings = {
     "gamma": sympy.gamma,
     "max": lambda x, y: sympy.Piecewise((y, x < y), (x, True)),
     "min": lambda x, y: sympy.Piecewise((x, x < y), (y, True)),
+    "round": lambda x: sympy.ceiling(x - 0.5),
 }
 
 


### PR DESCRIPTION
Enabling a workaround to avoid the following type error:

`raise TypeError("Cannot round symbolic expression")`

while using `round` as a unary operator.

This issue was raised in #269 the the PR contains the exact solution that was put forth in the subsequent discussion.