### PR TITLE
Warn the user on Python 3.12

### DIFF
--- a/pysr/__init__.py
+++ b/pysr/__init__.py
@@ -1,3 +1,12 @@
+import sys
+import warnings
+
+if sys.version_info >= (3, 12, 0):
+    warnings.warn(
+        "PySR experiences occassional segfaults with Python 3.12. "
+        + "Please use an earlier version of Python with PySR until this issue is resolved."
+    )
+
 from . import sklearn_monkeypatch
 from .deprecated import best, best_callable, best_row, best_tex, pysr
 from .export_jax import sympy2jax

--- a/pysr/version.py
+++ b/pysr/version.py
@@ -1,2 +1,2 @@
-__version__ = "0.16.6"
+__version__ = "0.16.7"
 __symbolic_regression_jl_version__ = "0.23.0"


### PR DESCRIPTION
I'm experiencing a lot of segfaults on Python 3.12. See https://github.com/JuliaPy/PyCall.jl/issues/1072 for updates.

Until this is resolved this PR will make PySR raise a warning on any post-3.12.0 version of Python recommending the user to downgrade Python.