### PR TITLE
Install `typing_extensions` for compatibility with Python 3.7

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -162,7 +162,10 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version:
+          - '3.11'
+          - '3.7'
+        os: ['ubuntu-latest']
 
     steps:
       - uses: actions/checkout@v3
@@ -174,8 +177,15 @@ jobs:
       - name: "Install PySR and all dependencies"
         run: |
             python -m pip install --upgrade pip
-            pip install -r requirements.txt
-            pip install mypy jax jaxlib torch
-            python setup.py install
+            python -m pip install -r requirements.txt
+            python -m pip install mypy
+            python -m pip install .
+      - name: "Install additional dependencies"
+        run: python -m pip install jax jaxlib torch
+        if: ${{ matrix.python-version != '3.7' }}
       - name: "Run mypy"
-        run: mypy --install-types --non-interactive pysr
+        run: python -m mypy --install-types --non-interactive pysr
+        if: ${{ matrix.python-version != '3.7' }}
+      - name: "Run compatible mypy"
+        run: python -m mypy --ignore-missing-imports pysr
+        if: ${{ matrix.python-version == '3.7' }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,11 +33,11 @@ jobs:
         python-version: ['3.11']
         os: [ubuntu-latest]
         test-id: ['main']
-      include:
-        - julia-version: ['1.6']
-          python-version: ['3.7']
-          os: [ubuntu-latest]
-          test-id: ['include']
+        include:
+          - julia-version: ['1.6']
+            python-version: ['3.7']
+            os: [ubuntu-latest]
+            test-id: ['include']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -104,7 +104,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ['3.11']
         os: ['ubuntu-latest']
 
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -84,7 +84,7 @@ jobs:
       - name: "Coveralls"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: test-${{ matrix.test-name }}
+          COVERALLS_FLAG_NAME: test-${{ matrix.julia-version }}-${{ matrix.python-version }}
           COVERALLS_PARALLEL: true
         run: coveralls --service=github
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,10 +32,12 @@ jobs:
         julia-version: ['1']
         python-version: ['3.11']
         os: [ubuntu-latest]
+        test-id: ['main']
       include:
         - julia-version: ['1.6']
           python-version: ['3.7']
           os: [ubuntu-latest]
+          test-id: ['include']
 
     steps:
       - uses: actions/checkout@v3
@@ -67,12 +69,16 @@ jobs:
             coverage run --append --source=pysr --omit='*/test/*,*/feynman_problems.py' -m pysr.test cli
       - name: "Install JAX"
         run: pip install jax jaxlib # (optional import)
+        if: ${{ matrix.test-id == 'main' }}
       - name: "Run JAX tests"
         run: coverage run --append --source=pysr --omit='*/test/*,*/feynman_problems.py' -m pysr.test jax
+        if: ${{ matrix.test-id == 'main' }}
       - name: "Install Torch"
         run: pip install torch # (optional import)
+        if: ${{ matrix.test-id == 'main' }}
       - name: "Run Torch tests"
         run: coverage run --append --source=pysr --omit='*/test/*,*/feynman_problems.py' -m pysr.test torch
+        if: ${{ matrix.test-id == 'main' }}
       - name: "Run custom env tests"
         run: coverage run --append --source=pysr --omit='*/test/*,*/feynman_problems.py' -m pysr.test env
       - name: "Coveralls"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,8 +29,8 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        julia-version: ['1.9']
-        python-version: ['3.10']
+        julia-version: ['1.6', '1']
+        python-version: ['3.7', '3.11']
         os: [ubuntu-latest]
 
     steps:
@@ -152,7 +152,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.11']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,9 +29,13 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        julia-version: ['1.6', '1']
-        python-version: ['3.7', '3.11']
+        julia-version: ['1']
+        python-version: ['3.11']
         os: [ubuntu-latest]
+      include:
+        - julia-version: ['1.6']
+          python-version: ['3.7']
+          os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,12 +32,12 @@ jobs:
         julia-version: ['1']
         python-version: ['3.11']
         os: [ubuntu-latest]
-        test-id: ['main']
+        test-id: [main]
         include:
-          - julia-version: ['1.6']
-            python-version: ['3.7']
-            os: [ubuntu-latest]
-            test-id: ['include']
+          - julia-version: '1.6'
+            python-version: '3.7'
+            os: ubuntu-latest
+            test-id: include
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/CI_Windows.yml
+++ b/.github/workflows/CI_Windows.yml
@@ -29,7 +29,7 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        julia-version: ['1.9']
+        julia-version: ['1']
         python-version: ['3.11']
         os: [windows-latest]
 

--- a/.github/workflows/CI_Windows.yml
+++ b/.github/workflows/CI_Windows.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         julia-version: ['1.9']
-        python-version: ['3.10']
+        python-version: ['3.11']
         os: [windows-latest]
 
     steps:

--- a/.github/workflows/CI_docker_large_nightly.yml
+++ b/.github/workflows/CI_docker_large_nightly.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.6', '1.9']
+        julia-version: ['1.6', '1']
         python-version: ['3.10']
         os: [ubuntu-latest]
         arch: ['linux/amd64', 'linux/arm64']

--- a/.github/workflows/CI_mac.yml
+++ b/.github/workflows/CI_mac.yml
@@ -29,8 +29,8 @@ jobs:
         shell: bash
     strategy:
       matrix:
-        julia-version: ['1.9']
-        python-version: ['3.10']
+        julia-version: ['1']
+        python-version: ['3.11']
         os: [macos-latest]
 
     steps:

--- a/.github/workflows/docker_deploy.yml
+++ b/.github/workflows/docker_deploy.yml
@@ -18,8 +18,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         arch: [linux/amd64]
-        python-version: [3.10.8]
-        julia-version: [1.8.2]
+        python-version: [3.11.6]
+        julia-version: [1.9.4]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # This builds a dockerfile containing a working copy of PySR
 # with all pre-requisites installed.
 
-ARG JLVERSION=1.9.1
-ARG PYVERSION=3.10.11
+ARG JLVERSION=1.9.4
+ARG PYVERSION=3.11.6
 ARG BASE_IMAGE=bullseye
 
 FROM julia:${JLVERSION}-${BASE_IMAGE} AS jl

--- a/pysr/export_latex.py
+++ b/pysr/export_latex.py
@@ -23,7 +23,7 @@ def sympy2latex(expr, prec=3, full_prec=True, **settings) -> str:
     """Convert sympy expression to LaTeX with custom precision."""
     settings["full_prec"] = full_prec
     printer = PreciseLatexPrinter(settings=settings, prec=prec)
-    return printer.doprint(expr)
+    return str(printer.doprint(expr))
 
 
 def generate_table_environment(

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -13,9 +13,9 @@ from multiprocessing import cpu_count
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
-try:
+if sys.version_info >= (3, 8):
     from typing import Literal
-except ImportError:
+else:
     from typing_extensions import Literal
 
 import numpy as np

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -11,7 +11,12 @@ from datetime import datetime
 from io import StringIO
 from multiprocessing import cpu_count
 from pathlib import Path
-from typing import Callable, Dict, List, Literal, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 import numpy as np
 import pandas as pd

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ scikit_learn>=1.0.0
 julia>=0.6.0
 click>=7.0.0
 setuptools>=50.0.0
-typing_extensions>=4.0.0,<5.0.0
+typing_extensions>=4.0.0,<5.0.0; python_version < "3.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ scikit_learn>=1.0.0
 julia>=0.6.0
 click>=7.0.0
 setuptools>=50.0.0
+typing_extensions>=4.0.0,<5.0.0

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,5 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.7",
 )


### PR DESCRIPTION
Since `typing.Literal` doesn't exist on Python 3.7, we need to install `typing_extensions` for such older versions.

Also updates the CI to test Python 3.7 & 3.11, and Julia 1.6 & 1.10