### PR TITLE
Limit to Julia 1.6.7-1.10.0 and 1.10.3+

### DIFF
--- a/pysr/juliapkg.json
+++ b/pysr/juliapkg.json
@@ -1,5 +1,5 @@
 {
-    "julia": "1.6",
+    "julia": "~1.6, ~1.7, ~1.8, ~1.9, =1.10.0, ^1.10.3",
     "packages": {
         "SymbolicRegression": {
             "uuid": "8254be44-1295-4e6a-a16d-46603ac705cb",


### PR DESCRIPTION
Fixes #561. Julia (actually libgomp) has a bug on 1.10.1 and 1.10.2 that causes a segfault on some RHEL distributions. So this skips those bad Julia versions.

More info: https://github.com/JuliaLang/julia/pull/53643