### PR TITLE
deps: downgrade PythonCall due to hanging precompilation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,5 +7,5 @@ dependencies:
   - pandas>=0.21.0,<3.0.0
   - numpy>=1.13.0,<2.0.0
   - scikit-learn>=1.0.0,<2.0.0
-  - pyjuliacall>=0.9.15,<0.10.0
+  - pyjuliacall>=0.9.21,<0.9.22
   - click>=7.0.0,<9.0.0

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -39,6 +39,7 @@ from .export_torch import sympy2torch
 from .feature_selection import run_feature_selection
 from .julia_extensions import load_required_packages
 from .julia_helpers import (
+    PythonCall,
     _escape_filename,
     _load_cluster_manager,
     jl_array,
@@ -1885,6 +1886,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         else:
             jl_y_variable_names = None
 
+        PythonCall.GC.disable()
         out = SymbolicRegression.equation_search(
             jl_X,
             jl_y,
@@ -1911,6 +1913,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             progress=progress and self.verbosity > 0 and len(y.shape) == 1,
             verbosity=int(self.verbosity),
         )
+        PythonCall.GC.enable()
 
         self.julia_state_stream_ = jl_serialize(out)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ sympy>=1.0.0,<2.0.0
 pandas>=0.21.0,<3.0.0
 numpy>=1.13.0,<3.0.0
 scikit_learn>=1.0.0,<2.0.0
-juliacall==0.9.22
+juliacall==0.9.21
 click>=7.0.0,<9.0.0
 setuptools>=50.0.0


### PR DESCRIPTION
https://github.com/JuliaPy/PythonCall.jl/issues/537

Strangely the new GC of PythonCall seems to cause hanging precompilation. I'm not exactly sure why.