### PR TITLE
Made from_file pickle loading more robust

### DIFF
--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1013,6 +1013,17 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             base_equation_file = os.path.basename(model.equation_file_)
             model.equation_file_ = os.path.join(base_dir, base_equation_file)
 
+            # Get constructor parameters and default values
+            params = inspect.signature(model.__init__).parameters
+
+            # Filter for missing parameters excluding kwargs
+            missing_params = {k: v for k, v in params.items() if
+                              k not in model.__dict__.keys() and v.name != "self" and v.kind != v.VAR_KEYWORD}
+
+            # Assign missing attributes
+            for k, v in missing_params.items():
+                setattr(model, k, v)
+            
             # Update any parameters if necessary, such as
             # extra_sympy_mappings:
             model.set_params(**pysr_kwargs)


### PR DESCRIPTION
Added backwards compatibility for loading models pickled under older versions.

Adds missing parameters with their default values.

See issue #700 