### PR TITLE
【Hackathon 7th No.1】 Integrate PaddlePaddle as a New Backend

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -81,6 +81,12 @@ jobs:
       - name: "Run Torch tests"
         run: coverage run --append -m pysr test torch
         if: ${{ matrix.test-id == 'main' }}
+      - name: "Install Paddle"
+        run: pip install paddle # (optional import)
+        if: ${{ matrix.test-id == 'main' }}
+      - name: "Run Paddle tests"
+        run: coverage run --append -m pysr test paddle
+        if: ${{ matrix.test-id == 'main' }}
       - name: "Coveralls"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -192,7 +198,7 @@ jobs:
             pip install .
             pip install mypy
       - name: "Install additional dependencies"
-        run: python -m pip install jax jaxlib torch
+        run: python -m pip install jax jaxlib torch paddlepaddle
         if: ${{ matrix.python-version != '3.8' }}
       - name: "Run mypy"
         run: python -m mypy --install-types --non-interactive pysr

--- a/.github/workflows/CI_Windows.yml
+++ b/.github/workflows/CI_Windows.yml
@@ -56,3 +56,7 @@ jobs:
         run: pip install torch # (optional import)
       - name: "Run Torch tests"
         run: python -m pysr test torch
+      - name: "Install Paddle"
+        run: pip install paddlepaddle # (optional import)
+      - name: "Run Paddle tests"
+        run: PYTHON_JULIACALL_THREADS=1 python -m pysr test paddle

--- a/.github/workflows/CI_mac.yml
+++ b/.github/workflows/CI_mac.yml
@@ -60,3 +60,7 @@ jobs:
         run: pip install torch # (optional import)
       - name: "Run Torch tests"
         run: python -m pysr test torch
+      - name: "Install Paddle"
+        run: pip install paddlepaddle # (optional import)
+      - name: "Run Paddle tests"
+        run: PYTHON_JULIACALL_THREADS=1 python -m pysr test paddle

--- a/examples/pysr_demo_paddle.py
+++ b/examples/pysr_demo_paddle.py
@@ -1,0 +1,115 @@
+import os
+
+import numpy as np
+import paddle
+from paddle import nn
+from paddle.io import DataLoader, TensorDataset
+from sklearn.model_selection import train_test_split
+
+os.environ["PYTHON_JULIACALL_THREADS"] = "1"
+
+rstate = np.random.RandomState(0)
+
+N = 100000
+Nt = 10
+X = 6 * rstate.rand(N, Nt, 5) - 3
+y_i = X[..., 0] ** 2 + 6 * np.cos(2 * X[..., 2])
+y = np.sum(y_i, axis=1) / y_i.shape[1]
+z = y**2
+
+
+hidden = 128
+total_steps = 50_000
+
+
+def mlp(size_in, size_out, act=nn.ReLU):
+    return nn.Sequential(
+        nn.Linear(size_in, hidden),
+        act(),
+        nn.Linear(hidden, hidden),
+        act(),
+        nn.Linear(hidden, hidden),
+        act(),
+        nn.Linear(hidden, size_out),
+    )
+
+
+class SumNet(nn.Layer):
+    def __init__(self):
+        super().__init__()
+
+        ########################################################
+        # The same inductive bias as above!
+        self.g = mlp(5, 1)
+        self.f = mlp(1, 1)
+
+    def forward(self, x):
+        y_i = self.g(x)[:, :, 0]
+        y = paddle.sum(y_i, axis=1, keepdim=True) / y_i.shape[1]
+        z = self.f(y)
+        return z[:, 0]
+
+
+Xt = paddle.to_tensor(X).astype("float32")
+zt = paddle.to_tensor(z).astype("float32")
+X_train, X_test, z_train, z_test = train_test_split(Xt, zt, random_state=0)
+train_set = TensorDataset([X_train, z_train])
+train = DataLoader(train_set, batch_size=128, shuffle=True)
+test_set = TensorDataset([X_test, z_test])
+test = DataLoader(test_set, batch_size=256)
+
+paddle.seed(0)
+
+model = SumNet()
+max_lr = 1e-2
+model = paddle.Model(model)
+scheduler = paddle.optimizer.lr.OneCycleLR(
+    max_learning_rate=max_lr, total_steps=total_steps, divide_factor=1e4
+)
+optim = paddle.optimizer.Adam(learning_rate=scheduler, parameters=model.parameters())
+model.prepare(optim, paddle.nn.MSELoss())
+model.fit(train, test, num_iters=total_steps, eval_freq=1000)
+
+np.random.seed(0)
+idx = np.random.randint(0, 10000, size=1000)
+
+X_for_pysr = Xt[idx]
+y_i_for_pysr = model.network.g(X_for_pysr)[:, :, 0]
+y_for_pysr = paddle.sum(y_i_for_pysr, axis=1) / y_i_for_pysr.shape[1]
+z_for_pysr = zt[idx]  # Use true values.
+
+
+nnet_recordings = {
+    "g_input": X_for_pysr.detach().cpu().numpy().reshape(-1, 5),
+    "g_output": y_i_for_pysr.detach().cpu().numpy().reshape(-1),
+    "f_input": y_for_pysr.detach().cpu().numpy().reshape(-1, 1),
+    "f_output": z_for_pysr.detach().cpu().numpy().reshape(-1),
+}
+
+# Save the data for later use:
+import pickle as pkl
+
+with open("nnet_recordings.pkl", "wb") as f:
+    pkl.dump(nnet_recordings, f)
+
+import pickle as pkl
+
+nnet_recordings = pkl.load(open("nnet_recordings.pkl", "rb"))
+f_input = nnet_recordings["f_input"]
+f_output = nnet_recordings["f_output"]
+g_input = nnet_recordings["g_input"]
+g_output = nnet_recordings["g_output"]
+
+
+rstate = np.random.RandomState(0)
+f_sample_idx = rstate.choice(f_input.shape[0], size=500, replace=False)
+from pysr import PySRRegressor
+
+model = PySRRegressor(
+    niterations=50,
+    binary_operators=["+", "-", "*"],
+    unary_operators=["cos", "square"],
+)
+model.fit(g_input[f_sample_idx], g_output[f_sample_idx])
+
+model.equations_[["complexity", "loss", "equation"]]

--- a/examples/pysr_demo_pytorch.py
+++ b/examples/pysr_demo_pytorch.py
@@ -1,0 +1,144 @@
+import os
+from multiprocessing import cpu_count
+
+import numpy as np
+import pytorch_lightning as pl
+import torch
+from sklearn.model_selection import train_test_split
+from torch import nn
+from torch.nn import functional as F
+from torch.utils.data import DataLoader, TensorDataset
+
+from pysr import PySRRegressor
+
+os.environ["PYTHON_JULIACALL_THREADS"] = "1"
+rstate = np.random.RandomState(0)
+
+N = 100000
+Nt = 10
+X = 6 * rstate.rand(N, Nt, 5) - 3
+y_i = X[..., 0] ** 2 + 6 * np.cos(2 * X[..., 2])
+y = np.sum(y_i, axis=1) / y_i.shape[1]
+z = y**2
+
+
+hidden = 128
+total_steps = 50_000
+
+
+def mlp(size_in, size_out, act=nn.ReLU):
+    return nn.Sequential(
+        nn.Linear(size_in, hidden),
+        act(),
+        nn.Linear(hidden, hidden),
+        act(),
+        nn.Linear(hidden, hidden),
+        act(),
+        nn.Linear(hidden, size_out),
+    )
+
+
+class SumNet(pl.LightningModule):
+    def __init__(self):
+        super().__init__()
+
+        ########################################################
+        # The same inductive bias as above!
+        self.g = mlp(5, 1)
+        self.f = mlp(1, 1)
+
+    def forward(self, x):
+        y_i = self.g(x)[:, :, 0]
+        y = torch.sum(y_i, dim=1, keepdim=True) / y_i.shape[1]
+        z = self.f(y)
+        return z[:, 0]
+
+    ########################################################
+
+    # PyTorch Lightning bookkeeping:
+    def training_step(self, batch, batch_idx):
+        x, z = batch
+        predicted_z = self(x)
+        loss = F.mse_loss(predicted_z, z)
+        return loss
+
+    def validation_step(self, batch, batch_idx):
+        return self.training_step(batch, batch_idx)
+
+    def configure_optimizers(self):
+        optimizer = torch.optim.Adam(self.parameters(), lr=self.max_lr)
+        scheduler = {
+            "scheduler": torch.optim.lr_scheduler.OneCycleLR(
+                optimizer,
+                max_lr=self.max_lr,
+                total_steps=self.trainer.estimated_stepping_batches,
+                final_div_factor=1e4,
+            ),
+            "interval": "step",
+        }
+        return [optimizer], [scheduler]
+
+
+Xt = torch.tensor(X).float()
+zt = torch.tensor(z).float()
+X_train, X_test, z_train, z_test = train_test_split(Xt, zt, random_state=0)
+train_set = TensorDataset(X_train, z_train)
+train = DataLoader(
+    train_set, batch_size=128, num_workers=cpu_count(), shuffle=True, pin_memory=True
+)
+test_set = TensorDataset(X_test, z_test)
+test = DataLoader(test_set, batch_size=256, num_workers=cpu_count(), pin_memory=True)
+
+pl.seed_everything(0)
+model = SumNet()
+model.total_steps = total_steps
+model.max_lr = 1e-2
+
+trainer = pl.Trainer(max_steps=total_steps, accelerator="gpu", devices=1)
+trainer.fit(model, train_dataloaders=train, val_dataloaders=test)
+
+
+np.random.seed(0)
+idx = np.random.randint(0, 10000, size=1000)
+
+X_for_pysr = Xt[idx]
+y_i_for_pysr = model.g(X_for_pysr)[:, :, 0]
+y_for_pysr = torch.sum(y_i_for_pysr, dim=1) / y_i_for_pysr.shape[1]
+z_for_pysr = zt[idx]  # Use true values.
+
+X_for_pysr.shape, y_i_for_pysr.shape
+
+
+nnet_recordings = {
+    "g_input": X_for_pysr.detach().cpu().numpy().reshape(-1, 5),
+    "g_output": y_i_for_pysr.detach().cpu().numpy().reshape(-1),
+    "f_input": y_for_pysr.detach().cpu().numpy().reshape(-1, 1),
+    "f_output": z_for_pysr.detach().cpu().numpy().reshape(-1),
+}
+
+# Save the data for later use:
+import pickle as pkl
+
+with open("nnet_recordings.pkl", "wb") as f:
+    pkl.dump(nnet_recordings, f)
+
+import pickle as pkl
+
+nnet_recordings = pkl.load(open("nnet_recordings.pkl", "rb"))
+f_input = nnet_recordings["f_input"]
+f_output = nnet_recordings["f_output"]
+g_input = nnet_recordings["g_input"]
+g_output = nnet_recordings["g_output"]
+
+
+rstate = np.random.RandomState(0)
+f_sample_idx = rstate.choice(f_input.shape[0], size=500, replace=False)
+
+model = PySRRegressor(
+    niterations=50,
+    binary_operators=["+", "-", "*"],
+    unary_operators=["cos", "square"],
+)
+model.fit(g_input[f_sample_idx], g_output[f_sample_idx])
+
+model.equations_[["complexity", "loss", "equation"]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,27 +5,25 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pysr"
 version = "0.19.4"
-authors = [
-    {name = "Miles Cranmer", email = "miles.cranmer@gmail.com"},
-]
+authors = [{ name = "Miles Cranmer", email = "miles.cranmer@gmail.com" }]
 description = "Simple and efficient symbolic regression"
-readme = {file = "README.md", content-type = "text/markdown"}
-license = {file = "LICENSE"}
+readme = { file = "README.md", content-type = "text/markdown" }
+license = { file = "LICENSE" }
 requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
-    "License :: OSI Approved :: Apache Software License"
+    "License :: OSI Approved :: Apache Software License",
 ]
 dynamic = ["dependencies"]
 
 [tool.setuptools]
 packages = ["pysr", "pysr._cli", "pysr.test"]
 include-package-data = false
-package-data = {pysr = ["juliapkg.json"]}
+package-data = { pysr = ["juliapkg.json"] }
 
 [tool.setuptools.dynamic]
-dependencies = {file = "requirements.txt"}
+dependencies = { file = "requirements.txt" }
 
 [tool.isort]
 profile = "black"
@@ -38,6 +36,7 @@ dev-dependencies = [
     "mypy>=1.10.0",
     "jax[cpu]>=0.4.26",
     "torch>=2.3.0",
+    "paddlepaddle>=2.6.1",
     "pandas-stubs>=2.2.1.240316",
     "types-pytz>=2024.1.0.20240417",
     "types-openpyxl>=3.1.0.20240428",

--- a/pysr/__init__.py
+++ b/pysr/__init__.py
@@ -6,6 +6,7 @@ from .julia_import import jl, SymbolicRegression  # isort:skip
 from . import sklearn_monkeypatch
 from .deprecated import best, best_callable, best_row, best_tex, install, pysr
 from .export_jax import sympy2jax
+from .export_paddle import sympy2paddle
 from .export_torch import sympy2torch
 from .julia_extensions import load_all_packages
 from .sr import PySRRegressor
@@ -19,6 +20,7 @@ __all__ = [
     "sklearn_monkeypatch",
     "sympy2jax",
     "sympy2torch",
+    "sympy2paddle",
     "install",
     "load_all_packages",
     "PySRRegressor",

--- a/pysr/_cli/main.py
+++ b/pysr/_cli/main.py
@@ -10,6 +10,7 @@ from ..test import (
     runtests,
     runtests_dev,
     runtests_jax,
+    runtests_paddle,
     runtests_startup,
     runtests_torch,
 )
@@ -48,7 +49,7 @@ def _install(julia_project, quiet, precompile):
     )
 
 
-TEST_OPTIONS = {"main", "jax", "torch", "cli", "dev", "startup"}
+TEST_OPTIONS = {"main", "jax", "torch", "paddle", "cli", "dev", "startup"}
 
 
 @pysr.command("test")
@@ -63,7 +64,7 @@ TEST_OPTIONS = {"main", "jax", "torch", "cli", "dev", "startup"}
 def _tests(tests, expressions):
     """Run parts of the PySR test suite.
 
-    Choose from main, jax, torch, cli, dev, and startup. You can give multiple tests, separated by commas.
+    Choose from main, jax, torch, paddle, cli, dev, and startup. You can give multiple tests, separated by commas.
     """
     test_cases = []
     for test in tests.split(","):
@@ -73,6 +74,8 @@ def _tests(tests, expressions):
             test_cases.extend(runtests_jax(just_tests=True))
         elif test == "torch":
             test_cases.extend(runtests_torch(just_tests=True))
+        elif test == "paddle":
+            test_cases.extend(runtests_paddle(just_tests=True))
         elif test == "cli":
             runtests_cli = get_runtests_cli()
             test_cases.extend(runtests_cli(just_tests=True))

--- a/pysr/export_paddle.py
+++ b/pysr/export_paddle.py
@@ -1,0 +1,224 @@
+import collections as co
+import functools as ft
+
+import numpy as np  # noqa: F401
+import sympy  # type: ignore
+
+
+def _reduce_add(*args):
+    return ft.reduce(lambda a, b: a + b, args)
+
+
+def _reduce_mul(*args):
+    return ft.reduce(lambda a, b: a * b, args)
+
+
+def _mod(a, b):
+    return a % b
+
+
+def _div(a, b):
+    return a / b
+
+
+paddle_initialized = False
+paddle = None
+SingleSymPyModule = None
+
+
+def _initialize_paddle():
+    global paddle_initialized
+    global paddle
+    global SingleSymPyModule
+
+    # Way to lazy load paddle, only if this is called,
+    # but still allow this module to be loaded in __init__
+    if not paddle_initialized:
+        import paddle as _paddle
+
+        paddle = _paddle
+
+        _global_func_lookup = {
+            sympy.Mul: _reduce_mul,
+            sympy.Add: _reduce_add,
+            sympy.div: _div,
+            sympy.Abs: paddle.abs,
+            sympy.sign: paddle.sign,
+            # Note: May raise error for ints.
+            sympy.ceiling: paddle.ceil,
+            sympy.floor: paddle.floor,
+            sympy.log: paddle.log,
+            sympy.exp: paddle.exp,
+            sympy.sqrt: paddle.sqrt,
+            sympy.cos: paddle.cos,
+            sympy.acos: paddle.acos,
+            sympy.sin: paddle.sin,
+            sympy.asin: paddle.asin,
+            sympy.tan: paddle.tan,
+            sympy.atan: paddle.atan,
+            sympy.atan2: paddle.atan2,
+            # Note: May give NaN for complex results.
+            sympy.cosh: paddle.cosh,
+            sympy.acosh: paddle.acosh,
+            sympy.sinh: paddle.sinh,
+            sympy.asinh: paddle.asinh,
+            sympy.tanh: paddle.tanh,
+            sympy.atanh: paddle.atanh,
+            sympy.Pow: paddle.pow,
+            sympy.re: paddle.real,
+            sympy.im: paddle.imag,
+            sympy.arg: paddle.angle,
+            # Note: May raise error for ints and complexes
+            sympy.erf: paddle.erf,
+            sympy.loggamma: paddle.lgamma,
+            sympy.Eq: paddle.equal,
+            sympy.Ne: paddle.not_equal,
+            sympy.StrictGreaterThan: paddle.greater_than,
+            sympy.StrictLessThan: paddle.less_than,
+            sympy.LessThan: paddle.less_equal,
+            sympy.GreaterThan: paddle.greater_equal,
+            sympy.And: paddle.logical_and,
+            sympy.Or: paddle.logical_or,
+            sympy.Not: paddle.logical_not,
+            sympy.Max: paddle.max,
+            sympy.Min: paddle.min,
+            sympy.Mod: _mod,
+            sympy.Heaviside: paddle.heaviside,
+            sympy.core.numbers.Half: (lambda: 0.5),
+            sympy.core.numbers.One: (lambda: 1.0),
+        }
+
+        class _Node(paddle.nn.Layer):
+            """Forked from https://github.com/patrick-kidger/sympypaddle"""
+
+            def __init__(self, *, expr, _memodict, _func_lookup, **kwargs):
+                super().__init__(**kwargs)
+
+                self._sympy_func = expr.func
+                if issubclass(expr.func, sympy.Float):
+                    self._value = paddle.create_parameter(
+                        shape=[1],
+                        dtype="float32",
+                        default_initializer=paddle.nn.initializer.Assign(
+                            paddle.to_tensor(float(expr))
+                        ),
+                    )
+                    self._paddle_func = lambda: self._value
+                    self._args = ()
+                elif issubclass(expr.func, sympy.Rational):
+                    # This is some fraction fixed in the operator.
+                    self._value = float(expr)
+                    self._paddle_func = lambda: self._value
+                    self._args = ()
+                elif issubclass(expr.func, sympy.UnevaluatedExpr):
+                    if len(expr.args) != 1 or not issubclass(
+                        expr.args[0].func, sympy.Float
+                    ):
+                        raise ValueError(
+                            "UnevaluatedExpr should only be used to wrap floats."
+                        )
+                    self.register_buffer(
+                        "_value", paddle.to_tensor(float(expr.args[0]))
+                    )
+                    self._paddle_func = lambda: self._value
+                    self._args = ()
+                elif issubclass(expr.func, sympy.Integer):
+                    # Can get here if expr is one of the Integer special cases,
+                    # e.g. NegativeOne
+                    self._value = int(expr)
+                    self._paddle_func = lambda: self._value
+                    self._args = ()
+                elif issubclass(expr.func, sympy.NumberSymbol):
+                    # Can get here from exp(1) or exact pi
+                    self._value = float(expr)
+                    self._paddle_func = lambda: self._value
+                    self._args = ()
+                elif issubclass(expr.func, sympy.Symbol):
+                    self._name = expr.name
+                    self._paddle_func = lambda value: value
+                    self._args = ((lambda memodict: memodict[expr.name]),)
+                else:
+                    try:
+                        self._paddle_func = _func_lookup[expr.func]
+                    except KeyError:
+                        raise KeyError(
+                            f"Function {expr.func} was not found in paddle function mappings."
+                            "Please add it to extra_paddle_mappings in the format, e.g., "
+                            "{sympy.sqrt: paddle.sqrt}."
+                        )
+                    args = []
+                    for arg in expr.args:
+                        try:
+                            arg_ = _memodict[arg]
+                        except KeyError:
+                            arg_ = type(self)(
+                                expr=arg,
+                                _memodict=_memodict,
+                                _func_lookup=_func_lookup,
+                                **kwargs,
+                            )
+                            _memodict[arg] = arg_
+                        args.append(arg_)
+                    self._args = paddle.nn.LayerList(args)
+
+            def extra_repr(self):
+                return (
+                    f"sympy_func={self._paddle_func.__name__}" + f"{self._sympy_func}"
+                )
+
+            def forward(self, memodict):
+                args = []
+                for arg in self._args:
+                    try:
+                        arg_ = memodict[arg]
+                    except KeyError:
+                        arg_ = arg(memodict)
+                        memodict[arg] = arg_
+                    args.append(arg_)
+                return self._paddle_func(*args)
+
+        class _SingleSymPyModule(paddle.nn.Layer):
+
+            def __init__(
+                self, expression, symbols_in, selection=None, extra_funcs=None, **kwargs
+            ):
+                super().__init__(**kwargs)
+
+                if extra_funcs is None:
+                    extra_funcs = {}
+                _func_lookup = co.ChainMap(_global_func_lookup, extra_funcs)
+
+                _memodict = {}
+                self._node = _Node(
+                    expr=expression, _memodict=_memodict, _func_lookup=_func_lookup
+                )
+                self._expression_string = str(expression)
+                self._selection = selection
+                self.symbols_in = [str(symbol) for symbol in symbols_in]
+
+            def __repr__(self):
+                return f"{type(self).__name__}(expression={self._expression_string})"
+
+            def forward(self, X):
+
+                if self._selection is not None:
+                    X = X[:, self._selection]
+                symbols = {symbol: X[:, i] for i, symbol in enumerate(self.symbols_in)}
+                return self._node(symbols)
+
+        SingleSymPyModule = _SingleSymPyModule
+
+
+def sympy2paddle(expression, symbols_in, selection=None, extra_paddle_mappings=None):
+    """Returns a module for a given sympy expression with trainable parameters;
+
+    This function will assume the input to the module is a matrix X, where
+        each column corresponds to each symbol you pass in `symbols_in`.
+    """
+    global SingleSymPyModule
+
+    _initialize_paddle()
+
+    return SingleSymPyModule(
+        expression, symbols_in, selection=selection, extra_funcs=extra_paddle_mappings
+    )

--- a/pysr/test/__init__.py
+++ b/pysr/test/__init__.py
@@ -2,6 +2,7 @@ from .test import runtests
 from .test_cli import get_runtests as get_runtests_cli
 from .test_dev import runtests as runtests_dev
 from .test_jax import runtests as runtests_jax
+from .test_paddle import runtests as runtests_paddle
 from .test_startup import runtests as runtests_startup
 from .test_torch import runtests as runtests_torch
 
@@ -9,6 +10,7 @@ __all__ = [
     "runtests",
     "runtests_jax",
     "runtests_torch",
+    "runtests_paddle",
     "get_runtests_cli",
     "runtests_startup",
     "runtests_dev",

--- a/pysr/test/test_paddle.py
+++ b/pysr/test/test_paddle.py
@@ -1,0 +1,241 @@
+import unittest
+
+import numpy as np
+import pandas as pd
+import sympy  # type: ignore
+
+import pysr
+from pysr import PySRRegressor, sympy2paddle
+
+
+class TestPaddle(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(0)
+        import paddle
+
+        paddle.disable_signal_handler()
+
+        self.paddle = paddle
+
+    def test_sympy2paddle(self):
+
+        x, y, z = sympy.symbols("x y z")
+        cosx = 1.0 * sympy.cos(x) + y
+
+        X = self.paddle.to_tensor(np.random.randn(1000, 3))
+        true = 1.0 * self.paddle.cos(X[:, 0]) + X[:, 1]
+        paddle_module = sympy2paddle(cosx, [x, y, z])
+
+        self.assertTrue(
+            np.all(np.isclose(paddle_module(X).detach().numpy(), true.detach().numpy()))
+        )
+
+    def test_pipeline_pandas(self):
+        X = pd.DataFrame(np.random.randn(100, 10))
+        y = np.ones(X.shape[0])
+        model = PySRRegressor(
+            progress=False,
+            max_evals=10000,
+            model_selection="accuracy",
+            extra_sympy_mappings={},
+            output_paddle_format=True,
+        )
+        model.fit(X, y)
+
+        equations = pd.DataFrame(
+            {
+                "Equation": ["1.0", "cos(x1)", "square(cos(x1))"],
+                "Loss": [1.0, 0.1, 1e-5],
+                "Complexity": [1, 2, 3],
+            }
+        )
+
+        equations["Complexity Loss Equation".split(" ")].to_csv(
+            "equation_file.csv.bkup"
+        )
+
+        model.refresh(checkpoint_file="equation_file.csv")
+        pdformat = model.paddle()
+        self.assertEqual(str(pdformat), "_SingleSymPyModule(expression=cos(x1)**2)")
+
+        np.testing.assert_almost_equal(
+            pdformat(self.paddle.to_tensor(X.values)).detach().numpy(),
+            np.square(np.cos(X.values[:, 1])),  # Selection 1st feature
+            decimal=3,
+        )
+
+    def test_pipeline(self):
+        X = np.random.randn(100, 10)
+        y = np.ones(X.shape[0])
+        model = PySRRegressor(
+            progress=False,
+            max_evals=10000,
+            model_selection="accuracy",
+            output_paddle_format=True,
+        )
+        model.fit(X, y)
+
+        equations = pd.DataFrame(
+            {
+                "Equation": ["1.0", "cos(x1)", "square(cos(x1))"],
+                "Loss": [1.0, 0.1, 1e-5],
+                "Complexity": [1, 2, 3],
+            }
+        )
+
+        equations["Complexity Loss Equation".split(" ")].to_csv(
+            "equation_file.csv.bkup"
+        )
+
+        model.refresh(checkpoint_file="equation_file.csv")
+
+        pdformat = model.paddle()
+        self.assertEqual(str(pdformat), "_SingleSymPyModule(expression=cos(x1)**2)")
+
+        np.testing.assert_almost_equal(
+            pdformat(self.paddle.to_tensor(X)).detach().numpy(),
+            np.square(np.cos(X[:, 1])),  # 2nd feature
+            decimal=3,
+        )
+
+    def test_mod_mapping(self):
+
+        x, y, z = sympy.symbols("x y z")
+        expression = x**2 + sympy.atanh(sympy.Mod(y + 1, 2) - 1) * 3.2 * z
+
+        module = sympy2paddle(expression, [x, y, z])
+
+        X = self.paddle.rand((100, 3)).astype("float32") * 10
+
+        true_out = (
+            X[:, 0] ** 2
+            + self.paddle.atanh(
+                self.paddle.mod(X[:, 1] + 1, self.paddle.to_tensor(2).astype("float32"))
+                - 1
+            )
+            * 3.2
+            * X[:, 2]
+        )
+        paddle_out = module(X)
+
+        np.testing.assert_array_almost_equal(
+            true_out.detach(), paddle_out.detach(), decimal=3
+        )
+
+    def test_custom_operator(self):
+        X = np.random.randn(100, 3)
+        y = np.ones(X.shape[0])
+        model = PySRRegressor(
+            progress=False,
+            max_evals=10000,
+            model_selection="accuracy",
+            output_paddle_format=True,
+        )
+        model.fit(X, y)
+
+        equations = pd.DataFrame(
+            {
+                "Equation": ["1.0", "mycustomoperator(x1)"],
+                "Loss": [1.0, 0.1],
+                "Complexity": [1, 2],
+            }
+        )
+
+        equations["Complexity Loss Equation".split(" ")].to_csv(
+            "equation_file_custom_operator.csv.bkup"
+        )
+
+        model.set_params(
+            equation_file="equation_file_custom_operator.csv",
+            extra_sympy_mappings={"mycustomoperator": sympy.sin},
+            extra_paddle_mappings={"mycustomoperator": self.paddle.sin},
+        )
+        model.refresh(checkpoint_file="equation_file_custom_operator.csv")
+        self.assertEqual(str(model.sympy()), "sin(x1)")
+        # Will automatically use the set global state from get_hof.
+
+        pdformat = model.paddle()
+        self.assertEqual(str(pdformat), "_SingleSymPyModule(expression=sin(x1))")
+
+        np.testing.assert_almost_equal(
+            pdformat(self.paddle.to_tensor(X)).detach().numpy(),
+            np.sin(X[:, 1]),
+            decimal=3,
+        )
+
+    def test_avoid_simplification(self):
+        # SymPy should not simplify without permission
+
+        ex = pysr.export_sympy.pysr2sympy(
+            "square(exp(sign(0.44796443))) + 1.5 * x1",
+            # ^ Normally this would become exp1 and require
+            #   its own mapping
+            feature_names_in=["x1"],
+            extra_sympy_mappings={"square": lambda x: x**2},
+        )
+        m = pysr.export_paddle.sympy2paddle(ex, ["x1"])
+        rng = np.random.RandomState(0)
+        X = rng.randn(10, 1)
+        np.testing.assert_almost_equal(
+            m(self.paddle.to_tensor(X)).detach().numpy(),
+            np.square(np.exp(np.sign(0.44796443))) + 1.5 * X[:, 0],
+            decimal=3,
+        )
+
+    def test_issue_656(self):
+
+        # Should correctly map numeric symbols to floats
+        E_plus_x1 = sympy.exp(1) + sympy.symbols("x1")
+        m = pysr.export_paddle.sympy2paddle(E_plus_x1, ["x1"])
+        X = np.random.randn(10, 1)
+        np.testing.assert_almost_equal(
+            m(self.paddle.to_tensor(X)).detach().numpy(),
+            np.exp(1) + X[:, 0],
+            decimal=3,
+        )
+
+    def test_feature_selection_custom_operators(self):
+        rstate = np.random.RandomState(0)
+        X = pd.DataFrame({f"k{i}": rstate.randn(2000) for i in range(10, 21)})
+
+        def cos_approx(x):
+            return 1 - (x**2) / 2 + (x**4) / 24 + (x**6) / 720
+
+        y = X["k15"] ** 2 + 2 * cos_approx(X["k20"])
+
+        model = PySRRegressor(
+            progress=False,
+            unary_operators=["cos_approx(x) = 1 - x^2 / 2 + x^4 / 24 + x^6 / 720"],
+            select_k_features=3,
+            maxsize=10,
+            early_stop_condition=1e-5,
+            extra_sympy_mappings={"cos_approx": cos_approx},
+            extra_paddle_mappings={"cos_approx": cos_approx},
+            random_state=0,
+            deterministic=True,
+            procs=0,
+            multithreading=False,
+        )
+        np.random.seed(0)
+        model.fit(X.values, y.values)
+        paddle_module = model.paddle()
+
+        np_output = model.predict(X.values)
+
+        paddle_output = paddle_module(self.paddle.to_tensor(X.values)).detach().numpy()
+
+        np.testing.assert_almost_equal(y.values, np_output, decimal=3)
+        np.testing.assert_almost_equal(y.values, paddle_output, decimal=3)
+
+
+def runtests(just_tests=False):
+    """Run all tests in test_paddle.py."""
+    tests = [TestPaddle]
+    if just_tests:
+        return tests
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    for test in tests:
+        suite.addTests(loader.loadTestsFromTestCase(test))
+    runner = unittest.TextTestRunner()
+    return runner.run(suite)


### PR DESCRIPTION
This PR introduces [PaddlePaddle](https://www.paddlepaddle.org.cn/en) backend support to the PySR library as part of my contribution to the [PaddlePaddle Hackathon 7th](https://github.com/PaddlePaddle/Paddle/issues/67603).

## Key Changes:
- Introduced PaddlePaddle-specific modules and functions.
- Updated the CI pipeline to include tests for the PaddlePaddle backend.
- Modified the example code to support PaddlePaddle

## Related Issues:

- https://github.com/PaddlePaddle/Paddle/issues/67603

## Issue Encountered:

During my integration process, I discovered that the method `SymbolicRegression.equation_search` causes a termination by signal, as shown in the following code snippet:
```python
class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
    def _run(...)
        ...
        out = SymbolicRegression.equation_search(...) <---terminated by signal SIGSEGV (Address boundary error)
        ...
```

Interestingly, this error does not occur when I set `PYTHON_JULIACALL_THREADS=1`. Below are some of the steps I took to investigate the issue:

After the termination, I checked `dmesg`, which returned the following:

```shell
[376826.886941] R13: 00007f3605750ba0 R14: 00007f35fe3ae8b0 R15: 00007f35fe3ae920
[376826.886942] R13: 00007f3605750ba0 R14: 00007f35fe3addc0 R15: 00007f35fe3ade30
[376826.886942] FS:  00007f358b7ff6c0 GS:  0000000000000000
[376826.886943] FS:  00007f35b60fc6c0 GS:  0000000000000000
[376826.886941] FS:  00007f3572ffe6c0 GS:  0000000000000000
[376826.886943] RBP: 00007f330b08ea10 R08: 00000000ffffffff R09: 00007f3605dc2dc8
[376826.886944] FS:  00007f3588ec06c0 GS:  0000000000000000
[376826.886943] RAX: 00007f360698f008 RBX: 00007f3605750b00 RCX: 0000000000000000
[376826.886945] FS:  00007f354f1fe6c0 GS:  0000000000000000
[376826.886945] R10: 00007f3605dc2820 R11: 00007f3605326040 R12: 00007f35fe3af6c0
[376826.886945] FS:  00007f359d3fc6c0 GS:  0000000000000000
[376826.886945] RDX: 0000000000000001 RSI: 00007f3605750b00 RDI: 0000000000000000
[376826.886946] R13: 00007f3605750ba0 R14: 00007f35fe3af6c0 R15: 00007f35fe3af730
[376826.886962] FS:  00007f357bfff6c0 GS:  0000000000000000
[376826.886962] RBP: 00007f330e88ea10 R08: 00000000ffffffff R09: 00007f3605dc2dc8
[376826.886963] R10: 00007f3605dc2820 R11: 00007f3605326040 R12: 00007f35fe3ae270
[376826.886964] R13: 00007f3605750ba0 R14: 00007f35fe3ae270 R15: 00007f35fe3ae2e0
[376826.886965] FS:  00007f35709fa6c0 GS:  0000000000000000
[376826.887626]  in libjulia-internal.so.1.10.4[7f3605453000+1c1000]
[376826.888187]  in libjulia-internal.so.1.10.4[7f3605453000+1c1000]
```

I also used `gdb --args python -m pysr test paddle` to inspect the stack trace. The output is as follows:

```shell
➜ gdb --args python -m pysr test paddle
...
(gdb) run
W0824 18:25:46.120416  7735 gpu_resources.cc:119] Please NOTE: device: 0, GPU Compute Capability: 8.9, Driver API Version: 12.6, Runtime API Version: 12.3
W0824 18:25:46.129973  7735 gpu_resources.cc:164] device: 0, cuDNN Version: 9.0.
.Compiling Julia backend...

Thread 6 "python" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffd61fd6c0 (LWP 7882)]
0x00007ffff5abaab7 in _jl_mutex_wait (self=self@entry=0x7fffef5b8e20, lock=lock@entry=0x7ffff5d50b00 <jl_codegen_lock>, safepoint=safepoint@entry=1) at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/threading.c:837
warning: 837    /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/threading.c: No such file or directory
(gdb) bt
#0  0x00007ffff5abaab7 in _jl_mutex_wait (self=self@entry=0x7fffef5b8e20, lock=lock@entry=0x7ffff5d50b00 <jl_codegen_lock>, safepoint=safepoint@entry=1) at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/threading.c:837
#1  0x00007ffff5abab63 in _jl_mutex_lock (self=self@entry=0x7fffef5b8e20, lock=0x7ffff5d50b00 <jl_codegen_lock>) at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/threading.c:875
#2  0x00007ffff5926100 in jl_mutex_lock (lock=<optimized out>) at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/julia_locks.h:65
#3  jl_generate_fptr_impl (mi=0x7ffe4c8c8d10 <jl_system_image_data+6611984>, world=31536, did_compile=0x7ffcf408eabc) at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/jitlayers.cpp:483
#4  0x00007ffff5a691b9 in jl_compile_method_internal (world=31536, mi=<optimized out>) at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/gf.c:2481
#5  jl_compile_method_internal (mi=<optimized out>, world=31536) at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/gf.c:2368
#6  0x00007ffff5a6a1be in _jl_invoke (world=31536, mfunc=0x7ffe4c8c8d10 <jl_system_image_data+6611984>, nargs=3, args=0x7ffcf408ebe0, F=0x7ffe4c566390 <jl_system_image_data+3062416>) at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/gf.c:2887
#7  ijl_apply_generic (F=<optimized out>, args=0x7ffcf408ebe0, nargs=<optimized out>) at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/gf.c:3077
#8  0x00007ffe4c23a44f in macro expansion () at /home/happy/.julia/packages/SymbolicRegression/9q4ZC/src/SingleIteration.jl:123
#9  julia_#271#threadsfor_fun#4_21198 () at threadingconstructs.jl:215
#10 0x00007ffe4c0d7cd0 in #271#threadsfor_fun () at threadingconstructs.jl:182
#11 julia_#1_24737 () at threadingconstructs.jl:154
#12 0x00007ffe4c123847 in jfptr_YY.1_24738 () from /home/happy/.julia/compiled/v1.10/SymbolicRegression/X2eIS_URG6E.so
#13 0x00007ffff5a69f8e in _jl_invoke (world=<optimized out>, mfunc=0x7ffe4c856190 <jl_system_image_data+6142096>, nargs=0, args=0x7fffef5b8e58, F=0x7ffe59c89110) at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/gf.c:2895
#14 ijl_apply_generic (F=<optimized out>, args=args@entry=0x7fffef5b8e58, nargs=nargs@entry=0) at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/gf.c:3077
#15 0x00007ffff5a8d310 in jl_apply (nargs=1, args=0x7fffef5b8e50) at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/julia.h:1982
#16 start_task () at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/task.c:1238
(gdb)
```

To be honest, I’m not very familiar with Julia, but it seems that the issue is related to multithreading within the SymbolicRegression library. I ran similar tests with the Torch backend, and below are the results:

```shell
➜ gdb --args python -m pysr test torch
(gdb) run
Thread 31 "python" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fff4dcc06c0 (LWP 9082)]
0x00007ffff5abaab7 in _jl_mutex_wait (self=self@entry=0x7fffee9addc0, lock=lock@entry=0x7ffff5d50b00 <jl_codegen_lock>, safepoint=safepoint@entry=1) at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/threading.c:837
warning: 837    /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/threading.c: No such file or directory
(gdb) bt
#0  0x00007ffff5abaab7 in _jl_mutex_wait (self=self@entry=0x7fffee9addc0, lock=lock@entry=0x7ffff5d50b00 <jl_codegen_lock>, safepoint=safepoint@entry=1) at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/threading.c:837
#1  0x00007ffff5abab63 in _jl_mutex_lock (self=self@entry=0x7fffee9addc0, lock=0x7ffff5d50b00 <jl_codegen_lock>) at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/threading.c:875
#2  0x00007ffff5926100 in jl_mutex_lock (lock=<optimized out>) at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/julia_locks.h:65
#3  jl_generate_fptr_impl (mi=0x7ffe56d90560, world=31536, did_compile=0x7ffd82c6207c) at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/jitlayers.cpp:483
#4  0x00007ffff5a691b9 in jl_compile_method_internal (world=31536, mi=<optimized out>) at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/gf.c:2481
#5  jl_compile_method_internal (mi=<optimized out>, world=31536) at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/gf.c:2368
#6  0x00007ffff5a6a1be in _jl_invoke (world=31536, mfunc=0x7ffe56d90560, nargs=2, args=0x7ffd82c621b0, F=0x7fffe22c81b0 <jl_system_image_data+3615344>) at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/gf.c:2887
#7  ijl_apply_generic (F=<optimized out>, args=0x7ffd82c621b0, nargs=<optimized out>) at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/gf.c:3077
#8  0x00007ffe4bfe13c3 in julia_optimize_and_simplify_population_21133 () at /home/happy/.julia/packages/SymbolicRegression/9q4ZC/src/SingleIteration.jl:110

#30 0x00007fffe6459970 in jl_system_image_data () from /home/happy/micromamba/julia_env/pyjuliapkg/install/lib/julia/sys.so
#31 0x00007fffe2c14290 in jl_system_image_data () from /home/happy/micromamba/julia_env/pyjuliapkg/install/lib/julia/sys.so
#32 0x0000000000000001 in ?? ()
#33 0x00007ffff5a72617 in jl_smallintset_lookup (cache=<optimized out>, eq=0x40, key=0x14, data=0x7ffe4f3d0010, hv=3) at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/smallintset.c:121
#34 0x00007fffdf4f82e5 in ?? ()
#35 0x00007ffe4f414218 in ?? ()
#36 0x00007fffef48c890 in ?? ()
#37 0x00007fffebb7f8f0 in ?? ()
#38 0x00007ffe4f3d0010 in ?? ()
#39 0x00007ffd82c62a40 in ?? ()
#40 0x00007ffff592846a in __gthread_mutex_unlock (__mutex=0x1) at /usr/local/x86_64-linux-gnu/include/c++/9.1.0/x86_64-linux-gnu/bits/gthr-default.h:779
#41 std::mutex::unlock (this=0x1) at /usr/local/x86_64-linux-gnu/include/c++/9.1.0/bits/std_mutex.h:118
#42 std::lock_guard<std::mutex>::~lock_guard (this=<synthetic pointer>, __in_chrg=<optimized out>) at /usr/local/x86_64-linux-gnu/include/c++/9.1.0/bits/std_mutex.h:165
#43 JuliaOJIT::ResourcePool<llvm::orc::ThreadSafeContext, 0ul, std::queue<llvm::orc::ThreadSafeContext, std::deque<llvm::orc::ThreadSafeContext, std::allocator<llvm::orc::ThreadSafeContext> > > >::release (resource=..., this=0x7ffd82c62ad0)
    at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/jitlayers.h:462
#44 JuliaOJIT::ResourcePool<llvm::orc::ThreadSafeContext, 0ul, std::queue<llvm::orc::ThreadSafeContext, std::deque<llvm::orc::ThreadSafeContext, std::allocator<llvm::orc::ThreadSafeContext> > > >::OwningResource::~OwningResource (this=0x0, __in_chrg=<optimized out>)
    at /cache/build/builder-amdci4-0/julialang/julia-release-1-dot-10/src/jitlayers.h:404
#45 0x00007fffdf4f83c4 in ?? ()
#46 0x0000000000000010 in ?? ()
#47 0x00007ffd82c62c60 in ?? ()
#48 0x0000000000000000 in ?? ()
(gdb)
```

I am encountering some challenges understanding the internal behavior of the SymbolicRegression library. I would greatly appreciate any guidance or suggestions on how to resolve this issue.