### PR TITLE
logger fixes: close streams and persist during warm start

### DIFF
--- a/pysr/logger_specs.py
+++ b/pysr/logger_specs.py
@@ -93,4 +93,3 @@ class TensorBoardLoggerSpec(AbstractLoggerSpec):
         """
         )
         close_logger(base_logger)
-        

--- a/pysr/logger_specs.py
+++ b/pysr/logger_specs.py
@@ -84,7 +84,7 @@ class TensorBoardLoggerSpec(AbstractLoggerSpec):
         base_logger = jl.SymbolicRegression.get_logger(logger)
         close_logger = jl.seval(
             """
-            function close_files!(lg::TensorBoardLogger.TBLogger)
+            function close_logger(lg::TensorBoardLogger.TBLogger)
                 # close open streams
                 for k=keys(lg.all_files)
                     close(lg.all_files[k])

--- a/pysr/logger_specs.py
+++ b/pysr/logger_specs.py
@@ -82,14 +82,4 @@ class TensorBoardLoggerSpec(AbstractLoggerSpec):
 
     def close(self, logger: AnyValue) -> None:
         base_logger = jl.SymbolicRegression.get_logger(logger)
-        close_logger = jl.seval(
-            """
-            function close_logger(lg::TensorBoardLogger.TBLogger)
-                # close open streams
-                for k=keys(lg.all_files)
-                    close(lg.all_files[k])
-                end
-            end
-        """
-        )
-        close_logger(base_logger)
+        jl.close(base_logger)

--- a/pysr/logger_specs.py
+++ b/pysr/logger_specs.py
@@ -19,6 +19,11 @@ class AbstractLoggerSpec(ABC):
         """Write hyperparameters to the logger."""
         pass  # pragma: no cover
 
+    @abstractmethod
+    def close(self, logger: AnyValue) -> None:
+        """Close the logger instance."""
+        pass  # pragma: no cover
+
 
 @dataclass
 class TensorBoardLoggerSpec(AbstractLoggerSpec):
@@ -74,3 +79,18 @@ class TensorBoardLoggerSpec(AbstractLoggerSpec):
                 ],
             ),
         )
+
+    def close(self, logger: AnyValue) -> None:
+        base_logger = jl.SymbolicRegression.get_logger(logger)
+        close_logger = jl.seval(
+            """
+            function close_files!(lg::TensorBoardLogger.TBLogger)
+                # close open streams
+                for k=keys(lg.all_files)
+                    close(lg.all_files[k])
+                end
+            end
+        """
+        )
+        close_logger(base_logger)
+        

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -2058,6 +2058,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         )
         if self.logger_spec is not None:
             self.logger_spec.write_hparams(logger, self.get_params())
+            self.logger_spec.close(logger)
 
         self.julia_state_stream_ = jl_serialize(out)
 


### PR DESCRIPTION
Hallo,

I have added an abstract 'dummy' method to close the logger in instance to AbstractLoggerSpec and a method with the same function for the TensorboardLoggerSpec. The method is called in sr.py after the logging file is completed. This enables the use of the parameter overwrite = True for the TensorBoardLoggerSpec and solves issue (Closes #761) .

Best regards