### PR TITLE
Parametric template expressions

### DIFF
--- a/.github/workflows/update_backend_version.py
+++ b/.github/workflows/update_backend_version.py
@@ -20,7 +20,7 @@ with open(juliapkg_json) as f:
 major, minor, patch, *dev = pyproject_data["project"]["version"].split(".")
 pyproject_data["project"]["version"] = f"{major}.{minor}.{int(patch)+1}"
 
-juliapkg_data["packages"]["SymbolicRegression"]["version"] = f"={new_backend_version}"
+juliapkg_data["packages"]["SymbolicRegression"]["version"] = f"~{new_backend_version}"
 
 with open(pyproject_toml, "w") as toml_file:
     toml_file.write(tomlkit.dumps(pyproject_data))

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -546,8 +546,9 @@ y = np.sin(X[:, 0] + X[:, 1]) + X[:, 2]**2
 
 # Define template: we want sin(f(x1, x2)) + g(x3)
 template = TemplateExpressionSpec(
-    function_symbols=["f", "g"],
-    combine="((; f, g), (x1, x2, x3)) -> sin(f(x1, x2)) + g(x3)",
+    expressions=["f", "g"],
+    variable_names=["x1", "x2", "x3"],
+    combine="sin(f(x1, x2)) + g(x3)",
 )
 
 model = PySRRegressor(
@@ -559,14 +560,22 @@ model = PySRRegressor(
 model.fit(X, y)
 ```
 
-You can also use no argument-functions for learning constants, like:
+You can also use parameters in your template expressions, which will be optimized during the search:
 
 ```python
 template = TemplateExpressionSpec(
-    function_symbols=["a", "f"],
-    combine="((; a, f), (x, y)) -> a() * sin(f(x, y))",
+    expressions=["f", "g"],
+    variable_names=["x1", "x2", "x3"],
+    parameters={"p1": 2, "p2": 1},  # p1 has length 2, p2 has length 1
+    combine="p1[1] * sin(f(x1, x2)) + p1[2] * g(x3) + p2[1]",
 )
 ```
+
+This will learn an equation of the form:
+
+$$ y = \alpha_1 \sin(f(x_1, x_2)) + \alpha_2 g(x_3) + \beta $$
+
+where $\alpha_1, \alpha_2$ are stored in `p1` and $\beta$ is stored in `p2`. The parameters will be optimized during the search.
 
 ### Parametric Expressions
 
@@ -608,6 +617,20 @@ model.fit(X, y, category=category)
 ```
 
 See [Expression Specifications](/api/#expression-specifications) for more details.
+
+You can also use `TemplateExpressionSpec` in the same way, passing
+the category as a column of `X`:
+
+```python
+spec = TemplateExpressionSpec(
+    expressions=["f", "g"],
+    variable_names=["x1", "x2", "class"],
+    combine="p1[class] * sin(f(x1, x2)) + p2[class]",
+)
+```
+
+this column will automatically be converted to integers.
+
 
 ## 12. Using TensorBoard for Logging
 

--- a/pysr/expression_specs.py
+++ b/pysr/expression_specs.py
@@ -1,5 +1,6 @@
 import copy
 from abc import ABC, abstractmethod
+from textwrap import dedent
 from typing import TYPE_CHECKING, Any, NewType, TypeAlias, overload
 
 import numpy as np
@@ -262,11 +263,13 @@ class TemplateExpressionSpec(AbstractExpressionSpec):
             template_inputs.append(
                 f"parameters=({', '.join([f'{p}={self.parameters[p]}' for p in self.parameters]) + ","})"
             )
-        return f"""
+        return dedent(
+            f"""
         @template_spec({", ".join(template_inputs) + ","}) do {", ".join(self.variable_names)}
             {self.combine}
         end
         """
+        )
 
     def julia_expression_options(self):
         f_combine = jl.seval(self.combine)

--- a/pysr/expression_specs.py
+++ b/pysr/expression_specs.py
@@ -258,14 +258,14 @@ class TemplateExpressionSpec(AbstractExpressionSpec):
         return jl.seval(self._template_macro_str())
 
     def _template_macro_str(self):
-        template_inputs = [f"expressions=({', '.join(self.expressions) + ","})"]
+        template_inputs = [f"expressions=({', '.join(self.expressions) + ','})"]
         if self.parameters:
             template_inputs.append(
-                f"parameters=({', '.join([f'{p}={self.parameters[p]}' for p in self.parameters]) + ","})"
+                f"parameters=({', '.join([f'{p}={self.parameters[p]}' for p in self.parameters]) + ','})"
             )
         return dedent(
             f"""
-        @template_spec({", ".join(template_inputs) + ","}) do {", ".join(self.variable_names)}
+        @template_spec({', '.join(template_inputs) + ','}) do {', '.join(self.variable_names)}
             {self.combine}
         end
         """

--- a/pysr/expression_specs.py
+++ b/pysr/expression_specs.py
@@ -182,7 +182,7 @@ class TemplateExpressionSpec(AbstractExpressionSpec):
         *,
         expressions: list[str],
         variable_names: list[str],
-        parameters: list[str] | None = None,
+        parameters: dict[str, int] | None = None,
     ) -> None: ...
 
     def __init__(

--- a/pysr/expression_specs.py
+++ b/pysr/expression_specs.py
@@ -165,7 +165,7 @@ class TemplateExpressionSpec(AbstractExpressionSpec):
     the derivative of f with respect to its first argument, evaluated at x.
     """
 
-    _spec_cache = {}
+    _spec_cache: dict[tuple[str, ...], AnyValue] = {}
 
     @overload
     def __init__(

--- a/pysr/expression_specs.py
+++ b/pysr/expression_specs.py
@@ -254,18 +254,19 @@ class TemplateExpressionSpec(AbstractExpressionSpec):
         return result
 
     def _call_template_macro(self):
-        template_inputs = [f"expressions=({', '.join(self.expressions)})"]
+        return jl.seval(self._template_macro_str())
+
+    def _template_macro_str(self):
+        template_inputs = [f"expressions=({', '.join(self.expressions) + ","})"]
         if self.parameters:
             template_inputs.append(
-                f"parameters=({', '.join([f'{p}={self.parameters[p]}' for p in self.parameters])})"
+                f"parameters=({', '.join([f'{p}={self.parameters[p]}' for p in self.parameters]) + ","})"
             )
-        return jl.seval(
-            f"""
-            @template_spec({", ".join(template_inputs)}) do {", ".join(self.variable_names)}
-                {self.combine}
-            end
-            """
-        )
+        return f"""
+        @template_spec({", ".join(template_inputs) + ","}) do {", ".join(self.variable_names)}
+            {self.combine}
+        end
+        """
 
     def julia_expression_options(self):
         f_combine = jl.seval(self.combine)

--- a/pysr/juliapkg.json
+++ b/pysr/juliapkg.json
@@ -3,7 +3,7 @@
     "packages": {
         "SymbolicRegression": {
             "uuid": "8254be44-1295-4e6a-a16d-46603ac705cb",
-            "version": "=1.7.1"
+            "version": "~1.7.1"
         },
         "Serialization": {
             "uuid": "9e88b42a-f829-5b0c-bbe9-9e923198166b",

--- a/pysr/juliapkg.json
+++ b/pysr/juliapkg.json
@@ -3,7 +3,7 @@
     "packages": {
         "SymbolicRegression": {
             "uuid": "8254be44-1295-4e6a-a16d-46603ac705cb",
-            "version": "=1.7.0"
+            "version": "=1.7.1"
         },
         "Serialization": {
             "uuid": "9e88b42a-f829-5b0c-bbe9-9e923198166b",

--- a/pysr/juliapkg.json
+++ b/pysr/juliapkg.json
@@ -3,7 +3,7 @@
     "packages": {
         "SymbolicRegression": {
             "uuid": "8254be44-1295-4e6a-a16d-46603ac705cb",
-            "version": "=1.5.2"
+            "version": "=1.7.0"
         },
         "Serialization": {
             "uuid": "9e88b42a-f829-5b0c-bbe9-9e923198166b",

--- a/pysr/param_groupings.yml
+++ b/pysr/param_groupings.yml
@@ -13,6 +13,7 @@
   - The Objective:
     - elementwise_loss
     - loss_function
+    - loss_function_expression
     - model_selection
     - dimensional_constraint_penalty
     - dimensionless_constants_only

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1116,6 +1116,12 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             if "equations_" not in model.__dict__ or model.equations_ is None:
                 model.refresh()
 
+            if model.expression_spec is not None:
+                warnings.warn(
+                    "Loading model from checkpoint file with a non-default expression spec "
+                    "is not fully supported as it relies on dynamic objects. This may result in unexpected behavior.",
+                )
+
             return model
         else:
             print(
@@ -1966,8 +1972,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             complexity_of_constants=self.complexity_of_constants,
             complexity_of_variables=complexity_of_variables,
             complexity_mapping=complexity_mapping,
-            expression_type=self.expression_spec_.julia_expression_type(),
-            expression_options=self.expression_spec_.julia_expression_options(),
+            expression_spec=self.expression_spec_.julia_expression_spec(),
             nested_constraints=nested_constraints,
             elementwise_loss=custom_loss,
             loss_function=custom_full_objective,

--- a/pysr/test/test_main.py
+++ b/pysr/test/test_main.py
@@ -47,7 +47,7 @@ os.environ["SYMBOLIC_REGRESSION_IS_TESTING"] = os.environ.get(
 )
 
 # Import from juliacall at end:
-from juliacall import JuliaError
+from juliacall import JuliaError  # type: ignore
 
 
 class TestPipeline(unittest.TestCase):

--- a/pysr/test/test_main.py
+++ b/pysr/test/test_main.py
@@ -1143,7 +1143,8 @@ class TestHelpMessages(unittest.TestCase):
     def test_suggest_keywords(self):
         # Easy
         self.assertEqual(
-            _suggest_keywords(PySRRegressor, "loss_function"), ["loss_function"]
+            _suggest_keywords(PySRRegressor, "loss_function"),
+            ["loss_function", "loss_function_expression"],
         )
 
         # More complex, and with error

--- a/pysr/test/test_main.py
+++ b/pysr/test/test_main.py
@@ -46,6 +46,9 @@ os.environ["SYMBOLIC_REGRESSION_IS_TESTING"] = os.environ.get(
     "SYMBOLIC_REGRESSION_IS_TESTING", "true"
 )
 
+# Import from juliacall at end:
+from juliacall import JuliaError
+
 
 class TestPipeline(unittest.TestCase):
     def setUp(self):
@@ -1100,9 +1103,9 @@ class TestHelpMessages(unittest.TestCase):
         bad_kwargs = [
             dict(
                 kwargs=dict(
-                    elementwise_loss="g(x, y) = 0.0", loss_function="f(*args) = 0.0"
+                    elementwise_loss="g(x, y) = 0.0", loss_function="f(args...) = 0.0"
                 ),
-                error=ValueError,
+                error=JuliaError,
             ),
             dict(
                 kwargs=dict(maxsize=3),


### PR DESCRIPTION
Includes parametric form of template expressions as well as `loss_function_expression` for custom loss functions on whole expression objects.

This is part of the v1.7 update to the backend: https://github.com/MilesCranmer/SymbolicRegression.jl/releases/tag/v1.7.0