### PR TITLE
Update backend to v1.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pysr"
-version = "1.4.1"
+version = "1.5.0"
 authors = [
     {name = "Miles Cranmer", email = "miles.cranmer@gmail.com"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pysr"
-version = "1.4.0"
+version = "1.4.1"
 authors = [
     {name = "Miles Cranmer", email = "miles.cranmer@gmail.com"},
 ]

--- a/pysr/juliapkg.json
+++ b/pysr/juliapkg.json
@@ -3,7 +3,7 @@
     "packages": {
         "SymbolicRegression": {
             "uuid": "8254be44-1295-4e6a-a16d-46603ac705cb",
-            "version": "~1.7.1"
+            "version": "~1.8.0"
         },
         "Serialization": {
             "uuid": "9e88b42a-f829-5b0c-bbe9-9e923198166b",

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -375,9 +375,6 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         You may pass a function with the same arguments as this (note
         that the name of the function doesn't matter). Here,
         both `prediction` and `dataset.y` are 1D arrays of length `dataset.n`.
-        If using `batching`, then you should add an
-        `idx` argument to the function, which is `nothing`
-        for non-batched, and a 1D array of indices for batched.
         Default is `None`.
     loss_function_expression : str
         Similar to `loss_function`, but takes as input the full


### PR DESCRIPTION
There is a slight behavioural changes here:

**New mini batches are sampled less frequently**. It now resamples only every iteration; rather than every eval - see MilesCranmer/SymbolicRegression.jl#421. This result in a speed improvement for code with `batching=true`. It should also result in improved search results, because comparison within a single population is more stable during evolution. In other words, there are no longer expressions that are ranked highly in the local population due to a "lucky batch"

Note that other than the slight behaviour change, this is otherwise backwards compatible - the old way to write custom loss functions that take indices will still be handled normally, without warnings or errors.

However, now you no longer have to write the fourth `idx` argument in custom loss functions. The dataset object itself will handle this (as it should have done anyways!). There is a `SubDataset <: Dataset` and `BasicDataset <: Dataset` rather than passing around an array idx explicitly.


Smaller changes:

- Allow recording family tree of expressions when doing crossovers (via `use_recorder`)
- Uses task local storage instead of thread local storage (needed for Julia 1.12 compatibility)
- Propagates errors on workers to the main thread, which results in cleaner stack traces. (uses `Base.errormonitor`)
- Some internal refactors to make code more readable, maintainable, etc.
