### PR TITLE
use standard library logging

### DIFF
--- a/pysr/__init__.py
+++ b/pysr/__init__.py
@@ -1,4 +1,11 @@
+import logging
 import os
+
+pysr_logger = logging.getLogger("pysr")
+pysr_logger.setLevel(logging.INFO)
+handler = logging.StreamHandler()
+handler.setLevel(logging.INFO)
+pysr_logger.addHandler(handler)
 
 if os.environ.get("PYSR_USE_BEARTYPE", "0") == "1":
     from beartype.claw import beartype_this_package

--- a/pysr/feature_selection.py
+++ b/pysr/feature_selection.py
@@ -1,5 +1,6 @@
 """Functions for doing feature selection during preprocessing."""
 
+import logging
 from typing import cast
 
 import numpy as np
@@ -7,6 +8,8 @@ from numpy import ndarray
 from numpy.typing import NDArray
 
 from .utils import ArrayLike
+
+pysr_logger = logging.getLogger(__name__)
 
 
 def run_feature_selection(
@@ -44,7 +47,7 @@ def _handle_feature_selection(
 ):
     if select_k_features is not None:
         selection = run_feature_selection(X, y, select_k_features)
-        print(f"Using features {[variable_names[i] for i in selection]}")
+        pysr_logger.info(f"Using features {[variable_names[i] for i in selection]}")
         X = X[:, selection]
     else:
         selection = None


### PR DESCRIPTION
There are a couple remaining lines that print to stdout. This changes those all to use a `logging.getLogger("pysr")` object so that users can more easily filter out printouts.