### PR TITLE
fix: typing extensions dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,3 +9,4 @@ dependencies:
   - scikit-learn>=1.0.0,<2.0.0
   - pyjuliacall>=0.9.22,<0.9.23
   - click>=7.0.0,<9.0.0
+  - typing-extensions>=4.0.0,<5.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "juliacall==0.9.24",
     "click>=7.0.0,<9.0.0",
     "setuptools>=50.0.0",
+    "typing-extensions>=4.0.0,<5.0.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pysr"
-version = "1.5.4"
+version = "1.5.5"
 authors = [
     {name = "Miles Cranmer", email = "miles.cranmer@gmail.com"},
 ]


### PR DESCRIPTION
Seems this error didn't show up during testing because one of the test dependencies installed it