### PR TITLE
Deprecate ParametricExpressionSpec in favor of TemplateExpressionSpec

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,5 @@ dependencies:
   - scikit-learn>=1.0.0,<2.0.0
   - pyjuliacall>=0.9.22,<0.9.23
   - click>=7.0.0,<9.0.0
+  - beartype>=0.19,<0.22
   - typing-extensions>=4.0.0,<5.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,12 +25,12 @@ dependencies = [
     "juliacall==0.9.24",
     "click>=7.0.0,<9.0.0",
     "setuptools>=50.0.0",
+    "beartype>=0.19,<0.22",
     "typing-extensions>=4.0.0,<5.0.0",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "beartype>=0.19,<0.21",
     "coverage>=7,<8",
     "coveralls>=4,<5",
     "ipykernel>=6,<7",

--- a/pysr/expression_specs.py
+++ b/pysr/expression_specs.py
@@ -327,15 +327,19 @@ def parametric_expression_deprecation_warning(
     variable_names = list(variable_names)
     combine_example = f"{function_name}({', '.join(variable_names + param_uses)})"
 
+    function_name_str = '"' + function_name + '"'
+    variable_name_str = ", ".join('"' + v + '"' for v in variable_names + ["category"])
+    param_defs_str = "{" + ", ".join(param_defs) + "}"
+
     message = (
         "ParametricExpressionSpec is deprecated. "
         "Please use TemplateExpressionSpec with parameters indexed by category instead.\n\n"
         "You could consider updating your code to use: \n"
         "```\n"
         "expression_spec = TemplateExpressionSpec(\n"
-        f'    expressions=["{function_name}"],\n'
-        f"    variable_names=[{', '.join(f'\"{v}\"' for v in variable_names + ['category'])}],\n"
-        f"    parameters={{{', '.join(param_defs)}}},\n"
+        f"    expressions=[{function_name_str}],\n"
+        f"    variable_names=[{variable_name_str}],\n"
+        f"    parameters={param_defs_str},\n"
         f'    combine="{combine_example}",\n'
         ")\n"
         "```\n"

--- a/pysr/expression_specs.py
+++ b/pysr/expression_specs.py
@@ -334,7 +334,7 @@ def parametric_expression_deprecation_warning(
         "```\n"
         "expression_spec = TemplateExpressionSpec(\n"
         f'    expressions=["{function_name}"],\n'
-        f"    variable_names=[{', '.join(f'"{v}"' for v in variable_names + ['category'])}],\n"
+        f"    variable_names=[{', '.join(f'\"{v}\"' for v in variable_names + ['category'])}],\n"
         f"    parameters={{{', '.join(param_defs)}}},\n"
         f'    combine="{combine_example}",\n'
         ")\n"

--- a/pysr/expression_specs.py
+++ b/pysr/expression_specs.py
@@ -347,7 +347,7 @@ def parametric_expression_deprecation_warning(
         "Then, add the category as a column in X: `X = np.column_stack([X, category])`, and avoid passing `category` to `fit`.\n"
     )
 
-    warnings.warn(message, FutureWarning, stacklevel=2)
+    warnings.warn(message, FutureWarning, stacklevel=3)
 
 
 class ParametricExpressionSpec(AbstractExpressionSpec):

--- a/pysr/expression_specs.py
+++ b/pysr/expression_specs.py
@@ -347,7 +347,7 @@ def parametric_expression_deprecation_warning(
         "Then, add the category as a column in X: `X = np.column_stack([X, category])`, and avoid passing `category` to `fit`.\n"
     )
 
-    warnings.warn(message, DeprecationWarning, stacklevel=2)
+    warnings.warn(message, FutureWarning, stacklevel=2)
 
 
 class ParametricExpressionSpec(AbstractExpressionSpec):

--- a/pysr/expression_specs.py
+++ b/pysr/expression_specs.py
@@ -328,7 +328,7 @@ def parametric_expression_deprecation_warning(
     combine_example = f"{function_name}({', '.join(variable_names + param_uses)})"
 
     message = (
-        "ParametricExpressionSpec is deprecated and will be removed in a future version. "
+        "ParametricExpressionSpec is deprecated. "
         "Please use TemplateExpressionSpec with parameters indexed by category instead.\n\n"
         "You could consider updating your code to use: \n"
         "```\n"

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -15,10 +15,11 @@ from dataclasses import dataclass, fields
 from io import StringIO
 from multiprocessing import cpu_count
 from pathlib import Path
-from typing import Any, List, Literal, Tuple, Union, cast
+from typing import Any, Literal, Tuple, Union, cast
 
 import numpy as np
 import pandas as pd
+from beartype.typing import List
 from numpy import ndarray
 from numpy.typing import NDArray
 from sklearn.base import BaseEstimator, MultiOutputMixin, RegressorMixin

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -39,6 +39,7 @@ from .expression_specs import (
     AbstractExpressionSpec,
     ExpressionSpec,
     ParametricExpressionSpec,
+    parametric_expression_deprecation_warning,
 )
 from .feature_selection import run_feature_selection
 from .julia_extensions import load_required_packages
@@ -2250,6 +2251,11 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
 
         random_state = check_random_state(self.random_state)  # For np random
         seed = cast(int, random_state.randint(0, 2**31 - 1))  # For julia random
+
+        if isinstance(self.expression_spec, ParametricExpressionSpec):
+            parametric_expression_deprecation_warning(
+                self.expression_spec.max_parameters, variable_names
+            )
 
         # Pre transformations (feature selection and denoising)
         X, y, variable_names, complexity_of_variables, X_units, y_units = (

--- a/pysr/test/test_main.py
+++ b/pysr/test/test_main.py
@@ -1037,7 +1037,9 @@ class TestMiscellaneous(unittest.TestCase):
         pattern = re.compile(
             r"ParametricExpressionSpec is deprecated"
             r".*TemplateExpressionSpec"
+            r".*expressions=\[\"f\"\]"
             r".*variable_names=\[\"alpha\", \"beta\", \"category\"\]"
+            r".*parameters=\{\"p1\": n_categories, \"p2\": n_categories\}"
             r".*combine=\"f\(alpha, beta, p1\[category\], p2\[category\]\)\"",
             flags=re.S,
         )

--- a/pysr/test/test_main.py
+++ b/pysr/test/test_main.py
@@ -1035,12 +1035,13 @@ class TestMiscellaneous(unittest.TestCase):
     def test_parametric_deprecation_warning(self):
         """Test that the helpful warning message is displayed."""
         pattern = re.compile(
-            r"ParametricExpressionSpec is deprecated"
-            r".*TemplateExpressionSpec"
-            r".*expressions=\[\"f\"\]"
-            r".*variable_names=\[\"alpha\", \"beta\", \"category\"\]"
-            r".*parameters=\{\"p1\": n_categories, \"p2\": n_categories\}"
-            r".*combine=\"f\(alpha, beta, p1\[category\], p2\[category\]\)\"",
+            r"ParametricExpressionSpec is deprecated.*TemplateExpressionSpec.*"
+            r"max_parameters=2.*"
+            r"variable_names=\[\"alpha\", \"beta\"\].*"
+            r"expressions=\[\"f\"\].*"
+            r"variable_names=\[\"alpha\", \"beta\", \"category\"\].*"
+            r"parameters=\{\s*\"p1\": n_categories,\s*\"p2\": n_categories\s*\}.*"
+            r"combine=\"f\(alpha, beta, p1\[category\], p2\[category\]\)\"",
             flags=re.S,
         )
 

--- a/pysr/test/test_main.py
+++ b/pysr/test/test_main.py
@@ -1044,7 +1044,7 @@ class TestMiscellaneous(unittest.TestCase):
             flags=re.S,
         )
 
-        with self.assertWarnsRegex(DeprecationWarning, pattern):
+        with self.assertWarnsRegex(FutureWarning, pattern):
             parametric_expression_deprecation_warning(
                 max_parameters=2,
                 variable_names=["alpha", "beta"],

--- a/pysr/test/test_main.py
+++ b/pysr/test/test_main.py
@@ -3,6 +3,7 @@ import importlib
 import os
 import pickle as pkl
 import platform
+import re
 import tempfile
 import traceback
 import unittest
@@ -32,6 +33,7 @@ from pysr import (
 )
 from pysr.export_latex import sympy2latex
 from pysr.export_sympy import pysr2sympy
+from pysr.expression_specs import parametric_expression_deprecation_warning
 from pysr.feature_selection import _handle_feature_selection, run_feature_selection
 from pysr.julia_helpers import init_julia
 from pysr.sr import (
@@ -1029,6 +1031,22 @@ class TestMiscellaneous(unittest.TestCase):
 
         # Check the sets are equal:
         self.assertSetEqual(set(params), set(regressor_params))
+
+    def test_parametric_deprecation_warning(self):
+        """Test that the helpful warning message is displayed."""
+        pattern = re.compile(
+            r"ParametricExpressionSpec is deprecated"
+            r".*TemplateExpressionSpec"
+            r".*variable_names=\[\"alpha\", \"beta\", \"category\"\]"
+            r".*combine=\"f\(alpha, beta, p1\[category\], p2\[category\]\)\"",
+            flags=re.S,
+        )
+
+        with self.assertWarnsRegex(DeprecationWarning, pattern):
+            parametric_expression_deprecation_warning(
+                max_parameters=2,
+                variable_names=["alpha", "beta"],
+            )
 
     def test_load_all_packages(self):
         """Test we can load all packages at once."""

--- a/pysr/utils.py
+++ b/pysr/utils.py
@@ -4,8 +4,9 @@ import difflib
 import inspect
 import re
 from pathlib import Path
-from typing import Any, List, TypeVar, Union
+from typing import Any, TypeVar, Union
 
+from beartype.typing import List
 from numpy import ndarray
 from sklearn.utils.validation import _check_feature_names_in  # type: ignore
 


### PR DESCRIPTION
This tries to give a helpful warning message to the user for how to upgrade to template expressions.

Suggested by @gm89uk as he found the performance was much better. So there's not much of a point in having a separate class anymore when template expressions are just better.

Care to take a look at the PR and let me know what you think? 