### PR TITLE
Enable negative losses

### DIFF
--- a/pysr/juliapkg.json
+++ b/pysr/juliapkg.json
@@ -3,7 +3,7 @@
     "packages": {
         "SymbolicRegression": {
             "uuid": "8254be44-1295-4e6a-a16d-46603ac705cb",
-            "version": "~1.10.0"
+            "version": "~1.11.0"
         },
         "Serialization": {
             "uuid": "9e88b42a-f829-5b0c-bbe9-9e923198166b",

--- a/pysr/param_groupings.yml
+++ b/pysr/param_groupings.yml
@@ -14,6 +14,7 @@
     - elementwise_loss
     - loss_function
     - loss_function_expression
+    - loss_scale
     - model_selection
     - dimensional_constraint_penalty
     - dimensionless_constants_only

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -387,6 +387,16 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         the innermost `AbstractExpressionNode`. This is useful
         for specifying custom loss functions on `TemplateExpressionSpec`.
         Default is `None`.
+    loss_scale : Literal["log", "linear"]
+        Determines how loss values are scaled when computing scores.
+        "log" (default) uses logarithmic scaling of loss ratios; this mode
+        requires non-negative loss values and is ideal for traditional
+        loss functions that are always non-negative.
+        "linear" uses direct
+        differences between losses; this mode handles any loss values
+        (including negative) and is useful for custom loss functions,
+        especially those based on likelihoods.
+        Default is "log".
     complexity_of_operators : dict[str, int | float]
         If you would like to use a complexity other than 1 for an
         operator, specify the complexity here. For example,
@@ -815,6 +825,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         elementwise_loss: str | None = None,
         loss_function: str | None = None,
         loss_function_expression: str | None = None,
+        loss_scale: Literal["log", "linear"] = "log",
         complexity_of_operators: dict[str, int | float] | None = None,
         complexity_of_constants: int | float | None = None,
         complexity_of_variables: int | float | list[int | float] | None = None,
@@ -922,6 +933,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         self.elementwise_loss = elementwise_loss
         self.loss_function = loss_function
         self.loss_function_expression = loss_function_expression
+        self.loss_scale = loss_scale
         self.complexity_of_operators = complexity_of_operators
         self.complexity_of_constants = complexity_of_constants
         self.complexity_of_variables = complexity_of_variables
@@ -1991,6 +2003,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             elementwise_loss=custom_loss,
             loss_function=custom_full_objective,
             loss_function_expression=custom_loss_expression,
+            loss_scale=jl.Symbol(self.loss_scale),
             maxsize=int(self.maxsize),
             output_directory=_escape_filename(self.output_directory_),
             npopulations=int(self.populations),

--- a/pysr/test/test_main.py
+++ b/pysr/test/test_main.py
@@ -759,6 +759,27 @@ class TestPipeline(unittest.TestCase):
                 # Verify model still works as expected
                 self.assertLessEqual(model.get_best()["loss"], 1e-4)
 
+    def test_negative_losses(self):
+        X = self.rstate.rand(100, 3) * 20.0
+        eps = self.rstate.randn(100)
+        y = np.cos(X[:, 0] * 2.1 - 0.5) + X[:, 1] ** 2 + 0.1 * eps
+        spec = TemplateExpressionSpec(
+            expressions=["f_mu", "f_logvar"],
+            variable_names=["x1", "x2", "x3", "y"],
+            combine="mu = f_mu(x1, x2, x3); logvar = f_logvar(x1, x2, x3); 0.5f0 * (logvar + (mu - y)^2 / exp(logvar))",
+        )
+        model = PySRRegressor(
+            **self.default_test_kwargs,
+            expression_spec=spec,
+            binary_operators=["+", "*", "-"],
+            unary_operators=["cos", "log", "exp"],
+            elementwise_loss="(pred, targ) -> pred",
+            loss_scale="linear",
+            early_stop_condition="stop_if_under_n1(loss, complexity) = loss < -1.0",
+        )
+        model.fit(np.column_stack([X, y]), 0 * y)
+        self.assertLessEqual(model.get_best()["loss"], -1.0)
+
     def test_comparison_operator(self):
         X = self.rstate.randn(100, 2)
         y = ((X[:, 0] + X[:, 1]) < (X[:, 0] * X[:, 1])).astype(float)


### PR DESCRIPTION
This adds the `loss_scale` parameter which, when set to `"linear"`, enables negative losses.

I also added a test with a negative-log-likelihood loss with a multi-output template expression.