### PR TITLE
ci: switch to codecov

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,12 +80,13 @@ jobs:
       - name: "Run Torch tests"
         run: coverage run --append -m pysr test torch
         if: ${{ matrix.test-id == 'main' }}
-      - name: "Coveralls"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: test-${{ matrix.julia-version }}-${{ matrix.python-version }}-${{ matrix.test-id }}
-          COVERALLS_PARALLEL: true
-        run: coveralls --service=github
+      - name: "Build coverage report"
+        run: coverage xml
+      - name: "Upload results to Codecov"
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: MilesCranmer/PySR
 
   dev_install:
     runs-on: ${{ matrix.os }}
@@ -147,23 +148,6 @@ jobs:
             python3 -c 'import pysr'
       - name: "Run tests"
         run: cd /tmp && python -m pysr test main
-
-  coveralls:
-    name: Indicate completion to coveralls.io
-    needs:
-      - test
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -l {0}
-    container: python:3-slim
-    steps:
-      - name: Finished
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-            pip install coveralls
-            coveralls --finish
 
   types:
     name: Check types

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you've finished a project with PySR, please submit a PR to showcase your work
 |---|---|---|
 |[![Linux](https://github.com/MilesCranmer/PySR/actions/workflows/CI.yml/badge.svg)](https://github.com/MilesCranmer/PySR/actions/workflows/CI.yml)|[![Windows](https://github.com/MilesCranmer/PySR/actions/workflows/CI_Windows.yml/badge.svg)](https://github.com/MilesCranmer/PySR/actions/workflows/CI_Windows.yml)|[![macOS](https://github.com/MilesCranmer/PySR/actions/workflows/CI_mac.yml/badge.svg)](https://github.com/MilesCranmer/PySR/actions/workflows/CI_mac.yml)|
 | **Docker** | **Conda** | **Coverage** |
-|[![Docker](https://github.com/MilesCranmer/PySR/actions/workflows/CI_docker.yml/badge.svg)](https://github.com/MilesCranmer/PySR/actions/workflows/CI_docker.yml)|[![conda-forge](https://github.com/MilesCranmer/PySR/actions/workflows/CI_conda_forge.yml/badge.svg)](https://github.com/MilesCranmer/PySR/actions/workflows/CI_conda_forge.yml)|[![Coverage Status](https://coveralls.io/repos/github/MilesCranmer/PySR/badge.svg?branch=master&service=github)](https://coveralls.io/github/MilesCranmer/PySR)|
+|[![Docker](https://github.com/MilesCranmer/PySR/actions/workflows/CI_docker.yml/badge.svg)](https://github.com/MilesCranmer/PySR/actions/workflows/CI_docker.yml)|[![conda-forge](https://github.com/MilesCranmer/PySR/actions/workflows/CI_conda_forge.yml/badge.svg)](https://github.com/MilesCranmer/PySR/actions/workflows/CI_conda_forge.yml)|[![codecov](https://codecov.io/gh/MilesCranmer/PySR/branch/master/graph/badge.svg)](https://codecov.io/gh/MilesCranmer/PySR)|
 
 </div>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "coverage>=7,<8",
-    "coveralls>=4,<5",
     "ipykernel>=6,<7",
     "ipython>=8,<9",
     "jax[cpu]>=0.4,<0.6",


### PR DESCRIPTION
Since coveralls-python hasn't updated to Python 3.13, we need to switch to codecov