### PR TITLE
fix: compat with python 3.8 by removing beartype

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,5 +9,4 @@ dependencies:
   - scikit-learn>=1.0.0,<2.0.0
   - pyjuliacall>=0.9.24,<0.9.26
   - click>=7.0.0,<9.0.0
-  - beartype>=0.19,<0.22
   - typing-extensions>=4.0.0,<5.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pysr"
-version = "1.5.7"
+version = "1.5.8"
 authors = [
     {name = "Miles Cranmer", email = "miles.cranmer@gmail.com"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,13 +24,13 @@ dependencies = [
     "scikit_learn>=1.0.0,<2.0.0",
     "juliacall>=0.9.24,<0.9.26",
     "click>=7.0.0,<9.0.0",
-    "beartype>=0.19,<0.22",
     "typing-extensions>=4.0.0,<5.0.0",
 ]
 
 [project.optional-dependencies]
 dev = [
     "coverage>=7,<8",
+    "beartype>=0.19,<0.22",
     "ipykernel>=6,<7",
     "ipython>=8,<9",
     "jax[cpu]>=0.4,<0.6",

--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -19,7 +19,6 @@ from typing import Any, Literal, Tuple, Union, cast
 
 import numpy as np
 import pandas as pd
-from beartype.typing import List
 from numpy import ndarray
 from numpy.typing import NDArray
 from sklearn.base import BaseEstimator, MultiOutputMixin, RegressorMixin
@@ -69,6 +68,12 @@ try:
     OLD_SKLEARN = False
 except ImportError:
     OLD_SKLEARN = True
+
+try:
+    from typing import List
+except ImportError:
+    from typing_extensions import List
+
 
 ALREADY_RAN = False
 

--- a/pysr/utils.py
+++ b/pysr/utils.py
@@ -6,9 +6,13 @@ import re
 from pathlib import Path
 from typing import Any, TypeVar, Union
 
-from beartype.typing import List
 from numpy import ndarray
 from sklearn.utils.validation import _check_feature_names_in  # type: ignore
+
+try:
+    from typing import List
+except ImportError:
+    from typing_extensions import List
 
 T = TypeVar("T", bound=Any)
 


### PR DESCRIPTION
beartype seems to have some builds on conda-forge that are incompatible with older python. These can't be removed without significant effort. But at the end of the day, we were only using the beartype import for one single type (`typing.List`, since Python will eventually deprecate this). Therefore, in order to keep compatibility with old versions, I need to remove beartype as a mandatory requirement. It turns out that `typing_extensions` also has a `List` so I'll just do that. 

Regardless, beartype is still used during testing.