### PR TITLE
feat: warn if `populations` is fewer than the number of worker processes

### DIFF
--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -2049,6 +2049,7 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         parallelism, numprocs = _map_parallelism_params(
             self.parallelism, self.procs, getattr(self, "multithreading", None)
         )
+        _warn_if_populations_lt_procs(self.populations, parallelism, numprocs)
 
         if self.deterministic and parallelism != "serial":
             raise ValueError(
@@ -3153,6 +3154,25 @@ def _mutate_parameter(param_name: str, param_value):
         return False
 
     return param_value
+
+
+def _warn_if_populations_lt_procs(
+    populations: int,
+    parallelism: Literal["serial", "multithreading", "multiprocessing"],
+    numprocs: int | None,
+) -> None:
+    if (
+        parallelism == "multiprocessing"
+        and numprocs is not None
+        and populations < numprocs
+    ):
+        warnings.warn(
+            f"`populations={populations}` is smaller than the resolved "
+            f"worker count (`numprocs={numprocs}`). Each population is assigned "
+            "to one worker, so the extra workers will sit idle for most of the "
+            "search. Consider increasing `populations` to at least the number "
+            "of workers (commonly 3-5x), or reducing `procs` to match."
+        )
 
 
 def _map_parallelism_params(

--- a/pysr/test/test_main.py
+++ b/pysr/test/test_main.py
@@ -14,6 +14,7 @@ from unittest import mock
 
 import numpy as np
 import pandas as pd
+import pytest
 import sympy  # type: ignore
 
 try:
@@ -43,6 +44,7 @@ from pysr.sr import (
     _suggest_keywords,
     _validate_elementwise_loss,
     _validate_export_mappings,
+    _warn_if_populations_lt_procs,
     idx_model_selection,
 )
 
@@ -61,6 +63,39 @@ os.environ["SYMBOLIC_REGRESSION_IS_TESTING"] = os.environ.get(
 
 # Import from juliacall at end:
 from juliacall import JuliaError  # type: ignore
+
+
+def test_warns_when_populations_less_than_procs():
+    with pytest.warns(UserWarning, match="populations.*smaller than"):
+        _warn_if_populations_lt_procs(
+            populations=4, parallelism="multiprocessing", numprocs=8
+        )
+
+
+def test_no_warn_when_populations_ge_procs():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _warn_if_populations_lt_procs(
+            populations=8, parallelism="multiprocessing", numprocs=8
+        )
+        _warn_if_populations_lt_procs(
+            populations=31, parallelism="multiprocessing", numprocs=8
+        )
+    assert not any("populations" in str(w.message) for w in caught)
+
+
+def test_no_warn_when_parallelism_not_multiprocessing():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _warn_if_populations_lt_procs(
+            populations=1, parallelism="serial", numprocs=None
+        )
+        _warn_if_populations_lt_procs(
+            populations=1,
+            parallelism="multithreading",
+            numprocs=None,
+        )
+    assert not any("populations" in str(w.message) for w in caught)
 
 
 class TestPipeline(unittest.TestCase):


### PR DESCRIPTION
## Summary

Single source-file edit plus one new test.

### Where to put the check

The warning has to fire AFTER `_map_parallelism_params` resolves the effective `numprocs`, because:

1. User may pass `parallelism='multiprocessing'` with `procs=None` -> `numprocs = cpu_count()` (`pysr/sr.py` line 3238).
2. User may pass `parallelism='serial'` -> `numprocs = None`, warning N/A.
3. User may pass `parallelism='multithreading'` -> `numprocs = None`; thread count comes from the Julia side. Out of scope; the warning would have to introspect Julia's `Threads.nthreads()`, which adds risk and noise. Document this as a non-goal in the PR body.

The call to `_map_parallelism_params` happens in `fit` at `pysr/sr.py` line 2049-2050:

```python
parallelism, numprocs = _map_parallelism_params(
    self.parallelism, self.procs, getattr(self, "multithreading", None)
)
```

Add the warning immediately after this block, alongside the existing `if self.deterministic and parallelism != "serial"` check (line 2053):

```python
if (
    parallelism == "multiprocessing"
    and numprocs is not None
    and self.populations < numprocs
):
    warnings.warn(
        f"`populations={self.populations}` is smaller than the resolved "
        f"worker count (`numprocs={numprocs}`). Each population is assigned "
        "to one worker, so the extra workers will sit idle for most of the "
        "search. Consider increasing `populations` to at least the number "
        "of workers (commonly 3-5x), or reducing `procs` to match."
    )
```

### Style match

This mirrors the existing nearby warnings (lines 2053-2069 in `pysr/sr.py`) for parallelism/deterministic mismatch and parallelism/cluster_manager mismatch - same call site, same `warnings.warn(...)` shape, same advice-then-fix tone.

### Test

Add to `pysr/test/test_main.py` (existing file already imports `pytest`, `warnings`, and constructs `PySRRegressor`):

```python
def test_warns_when_populations_less_than_procs():
    # multiprocessing path: explicit procs > populations -> warn
    model = PySRRegressor(
        parallelism="multiprocessing",
        procs=8,
        populations=4,
        niterations=1,  # silence the low-niterations warning from #603 if both land
    )
    # We don't want to spin up Julia. Patch the bit of fit that triggers Julia.
    # Easier path: extract the warning check into a small helper and test it
    # directly, or call _map_parallelism_params + the new conditional inline.
    from pysr.sr import _map_parallelism_params
    parallelism, numprocs = _map_parallelism_params(
        model.parallelism, model.procs, getattr(model, "multithreading", None)
    )
    assert parallelism == "multiprocessing"
    assert numprocs == 8
    # Reproduce the inlined warning check (one-liner mirror of the new code):
    with pytest.warns(UserWarning, match="populations.*smaller than"):
        if (
            parallelism == "multiprocessing"
            and numprocs is not None
            and model.populations < numprocs
        ):
            import warnings as _w
            _w.warn(
                f"`populations={model.populations}` is smaller than the resolved "
                f"worker count (`numprocs={numprocs}`)."
            )
```

Prefer extracting the new warning into a tiny helper `_warn_if_populations_lt_procs(populations, parallelism, numprocs)` in `pysr/sr.py` and calling that from `fit`. Then the test calls the helper directly with no Julia involvement:

```python
from pysr.sr import _warn_if_populations_lt_procs
import warnings, pytest

def test_warns_when_populations_less_than_procs():
    with pytest.warns(UserWarning, match="populations.*smaller than"):
        _warn_if_populations_lt_procs(populations=4, parallelism="multiprocessing", numprocs=8)

def test_no_warn_when_populations_ge_procs():
    with warnings.catch_warnings(record=True) as caught:
        warnings.simplefilter("always")
        _warn_if_populations_lt_procs(populations=8, parallelism="multiprocessing", numprocs=8)
        _warn_if_populations_lt_procs(populations=31, parallelism="multiprocessing", numprocs=8)
    assert not any("populations" in str(w.message) for w in caught)

def test_no_warn_when_parallelism_not_multiprocessing():
    with warnings.catch_warnings(record=True) as caught:
        warnings.simplefilter("always")
        _warn_if_populations_lt_procs(populations=1, parallelism="serial", numprocs=None)
        _warn_if_populations_lt_procs(populations=1, parallelism="multithreading", numprocs=None)
    assert not any("populations" in str(w.message) for w in caught)
```

This extraction is the lightest-touch refactor that makes the new behavior testable without spinning up Julia. The helper is private (`_` prefix), so no API surface impact.

### PR body

> Towards #595.
>
> Adds a `UserWarning` when `parallelism='multiprocessing'` with `populations < numprocs`, since the extra workers will sit idle. Suggests "increase populations to at least numprocs, or reduce procs to match."
>
> The check is extracted into a tiny private helper `_warn_if_populations_lt_procs` so the test in `pysr/test/test_main.py` can exercise it without spinning up Julia.
>
> Non-goal (called out for reviewers): `parallelism='multithreading'` does not expose a Python-side thread count from `_map_parallelism_params` - the thread count comes from the Julia side. This PR intentionally skips the multithreading case; happy to extend in a follow-up if you want a Julia-side check.

## Why this matters

`MilesCranmer/PySR#595` (authored by Miles 2024-04-04):

> Sometimes users use fewer populations than processes available. Would be good to warn them if this occurs.

Background: PySR runs `populations` independent evolutionary populations and distributes them across worker processes. When `populations < procs`, some workers sit idle, which is almost certainly not what the user wants. The current default `populations=31` (`pysr/sr.py` line 957) is fine for `procs<=31`, but users who pass a small `populations` explicitly often don't realize they are starving workers.

## Testing

- `pytest pysr/test/test_main.py::test_warns_when_populations_less_than_procs pysr/test/test_main.py::test_no_warn_when_populations_ge_procs pysr/test/test_main.py::test_no_warn_when_parallelism_not_multiprocessing -q` all pass.
- `pytest pysr/test/test_main.py -q` passes; no spurious warnings introduced in unrelated tests.
- `python -c "from pysr.sr import _warn_if_populations_lt_procs; _warn_if_populations_lt_procs(4, 'multiprocessing', 8)"` prints a `UserWarning` mentioning `populations` and `numprocs`.
- `python -c "from pysr.sr import _warn_if_populations_lt_procs; _warn_if_populations_lt_procs(8, 'multiprocessing', 8)"` prints no warning (equal case is fine).
- `python -c "from pysr.sr import _warn_if_populations_lt_procs; _warn_if_populations_lt_procs(1, 'serial', None)"` prints no warning.
- `grep -n "_warn_if_populations_lt_procs" pysr/sr.py pysr/test/test_main.py` returns one definition, one call site in `fit`, and the test references.
- `python -m mypy pysr/sr.py` reports no new errors.
- `ruff check pysr/sr.py pysr/test/test_main.py` reports no new findings.

Fixes #595

AI was used for assistance.
