### PR TITLE
Clear extra_jax_mappings before pickling

### DIFF
--- a/pysr/sr.py
+++ b/pysr/sr.py
@@ -1424,7 +1424,11 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
         show_pickle_warning = not (
             "show_pickle_warnings_" in state and not state["show_pickle_warnings_"]
         )
-        state_keys_containing_lambdas = ["extra_sympy_mappings", "extra_torch_mappings"]
+        state_keys_containing_lambdas = [
+            "extra_sympy_mappings",
+            "extra_torch_mappings",
+            "extra_jax_mappings",
+        ]
         for state_key in state_keys_containing_lambdas:
             warn_msg = (
                 f"`{state_key}` cannot be pickled and will be removed from the "
@@ -1478,7 +1482,9 @@ class PySRRegressor(MultiOutputMixin, RegressorMixin, BaseEstimator):
             try:
                 pkl.dump(self, f)
             except Exception as e:
-                pysr_logger.debug(f"Error checkpointing model: {e}")
+                pysr_logger.warning(
+                    f"Error checkpointing model to {self.get_pkl_filename()}: {e}"
+                )
         self.show_pickle_warnings_ = True
 
     def get_pkl_filename(self) -> Path:

--- a/pysr/test/test_main.py
+++ b/pysr/test/test_main.py
@@ -1459,6 +1459,23 @@ class TestMiscellaneous(unittest.TestCase):
         # Check that the same operator mapping was used (1/x for inv)
         self.assertEqual(original_result, 0.5 + 3.0)  # 1/2 + 3 = 3.5
 
+    def test_getstate_clears_extra_jax_mappings(self):
+        """Regression test: unpicklable callables in `extra_jax_mappings`
+        must not end up in `__getstate__`'s output, mirroring the existing
+        handling of `extra_sympy_mappings`/`extra_torch_mappings`."""
+        model = PySRRegressor(
+            extra_jax_mappings={(lambda x: x): "(lambda x: x)"},
+        )
+        # A raw dict with a lambda key cannot be pickled at all:
+        with self.assertRaises(Exception):
+            pkl.dumps(model.extra_jax_mappings)
+
+        # But `__getstate__` should have cleared it, so the model itself
+        # pickles fine:
+        state = model.__getstate__()
+        self.assertIsNone(state["extra_jax_mappings"])
+        pkl.dumps(state)
+
     def test_predict_replaces_spaces_in_dataframe_columns(self):
         # Regression for #690.
         model = PySRRegressor(


### PR DESCRIPTION
## Summary
`PySRRegressor.__getstate__` clears `extra_sympy_mappings` and `extra_torch_mappings` before pickling, since both hold live callables that generally can't be pickled (e.g. lambdas, locally-defined functions). `extra_jax_mappings` has the exact same shape (`dict[Callable, str]`) but was missing from that list.

When a user passes a custom function there (the documented/intended use case — see `extra_jax_mappings : dict[Callable, str]` in the docstring), `_checkpoint()`'s `pkl.dump(self, f)` fails. That failure is caught and logged at `debug` level only, so by default it's invisible — and since the file was already opened in `"wb"` mode (truncating it first), the result is an empty/truncated pickle file. Loading it later via `PySRRegressor.from_file()` then fails with a confusing `EOFError: Ran out of input`, with no indication of the real cause.

This:
- adds `extra_jax_mappings` to the list of state keys cleared in `__getstate__`, matching `extra_sympy_mappings`/`extra_torch_mappings`
- surfaces checkpoint failures via `pysr_logger.warning(...)` instead of `debug(...)`, so a genuine pickling failure isn't silent

Fixes #1198

## Test plan
- [x] Added `test_getstate_clears_extra_jax_mappings`: a model with an unpicklable lambda in `extra_jax_mappings` fails to pickle the raw dict directly, but `__getstate__()`'s output pickles fine and has `extra_jax_mappings` set to `None`
- [x] `pysr/test/test_main.py -k "getstate_clears_extra_jax_mappings or pickle"` passes (3/3)